### PR TITLE
Add missing documentation pages

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,63 +1,6 @@
 <ul class="nav-list">
-  {%- assign included_pages = include.pages
-        | where_exp:"item", "item.nav_exclude != true"
-        | where_exp:"item", "item.title != nil" -%}
+  {%- include sort_pages.html pages=include.pages -%}
 
-  {%- comment -%}
-    The values of `title` and `nav_order` can be numbers or strings.
-    Jekyll gives build failures when sorting on mixtures of different types,
-    so numbers and strings need to be sorted separately.
-
-    Here, numbers are sorted by their values, and come before all strings.
-    An omitted `nav_order` value is equivalent to the page's `title` value
-    (except that a numerical `title` value is treated as a string).
-
-    The case-sensitivity of string sorting is determined by `site.nav_sort`.
-  {%- endcomment -%}
-  
-  {%- assign string_ordered_pages = included_pages
-        | where_exp:"item", "item.nav_order == nil" -%}
-  {%- assign nav_ordered_pages = included_pages
-        | where_exp:"item", "item.nav_order != nil"  -%}
-
-  {%- comment -%}
-    The nav_ordered_pages have to be added to number_ordered_pages and
-    string_ordered_pages, depending on the nav_order value.
-    The first character of the jsonify result is `"` only for strings.
-  {%- endcomment -%}
-  {%- assign nav_ordered_groups = nav_ordered_pages
-        | group_by_exp:"item", "item.nav_order | jsonify | slice: 0" -%}
-  {%- assign number_ordered_pages = "" | split:"X" -%}
-  {%- for group in nav_ordered_groups -%}
-    {%- if group.name == '"' -%}
-      {%- assign string_ordered_pages = string_ordered_pages | concat: group.items -%}
-    {%- else -%}
-      {%- assign number_ordered_pages = number_ordered_pages | concat: group.items -%}
-    {%- endif -%}
-  {%- endfor -%}
-  
-  {%- assign sorted_number_ordered_pages = number_ordered_pages | sort:"nav_order" -%}
-  
-  {%- comment -%}
-    The string_ordered_pages have to be sorted by nav_order, and otherwise title
-    (where appending the empty string to a numeric title converts it to a string).
-    After grouping them by those values, the groups are sorted, then the items
-    of each group are concatenated.
-  {%- endcomment -%}
-  {%- assign string_ordered_groups = string_ordered_pages
-        | group_by_exp:"item", "item.nav_order | default: item.title | append:''" -%}
-  {%- if site.nav_sort == 'case_insensitive' -%}
-    {%- assign sorted_string_ordered_groups = string_ordered_groups | sort_natural:"name" -%}
-  {%- else -%}
-    {%- assign sorted_string_ordered_groups = string_ordered_groups | sort:"name" -%}
-  {%- endif -%}
-  {%- assign sorted_string_ordered_pages = "" | split:"X" -%}
-  {%- for group in sorted_string_ordered_groups -%}
-    {%- assign sorted_string_ordered_pages = sorted_string_ordered_pages | concat: group.items -%}
-  {%- endfor -%}
-
-  {%- assign pages_list = sorted_number_ordered_pages | concat: sorted_string_ordered_pages -%}
-  
   {%- for node in pages_list -%}
     {%- if node.parent == nil -%}
       <li class="nav-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">

--- a/_includes/page_nav.html
+++ b/_includes/page_nav.html
@@ -1,0 +1,74 @@
+{%- comment -%}
+  Renders "Previous" / "Next" buttons that follow the sidebar navigation order.
+
+  It rebuilds the flat, depth-first order of the sidebar (top-level pages, then
+  their children, then grand-children — each level sorted like nav.html), finds
+  the current page in that order, and links to the pages immediately before and
+  after it.
+{%- endcomment -%}
+{%- include sort_pages.html pages=site.html_pages -%}
+
+{%- comment -%} Flatten pages_list into sidebar (depth-first) order. {%- endcomment -%}
+{%- assign flat_pages = "" | split:"X" -%}
+{%- for node in pages_list -%}
+  {%- if node.parent == nil -%}
+    {%- assign node_arr = pages_list | where:"url", node.url -%}
+    {%- assign flat_pages = flat_pages | concat: node_arr -%}
+    {%- if node.has_children -%}
+      {%- assign children = pages_list | where:"parent", node.title -%}
+      {%- for child in children -%}
+        {%- assign child_arr = pages_list | where:"url", child.url -%}
+        {%- assign flat_pages = flat_pages | concat: child_arr -%}
+        {%- if child.has_children -%}
+          {%- assign grand_children = pages_list | where:"parent", child.title | where:"grand_parent", node.title -%}
+          {%- assign flat_pages = flat_pages | concat: grand_children -%}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- comment -%} Locate the current page in the flattened order. {%- endcomment -%}
+{%- assign found = false -%}
+{%- assign cur_index = 0 -%}
+{%- for p in flat_pages -%}
+  {%- if p.url == page.url -%}
+    {%- assign found = true -%}
+    {%- assign cur_index = forloop.index0 -%}
+    {%- break -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- if found -%}
+  {%- assign prev_page = nil -%}
+  {%- assign next_page = nil -%}
+  {%- if cur_index > 0 -%}
+    {%- assign prev_index = cur_index | minus: 1 -%}
+    {%- assign prev_page = flat_pages[prev_index] -%}
+  {%- endif -%}
+  {%- assign next_index = cur_index | plus: 1 -%}
+  {%- if next_index < flat_pages.size -%}
+    {%- assign next_page = flat_pages[next_index] -%}
+  {%- endif -%}
+
+  {%- if prev_page or next_page -%}
+    <nav class="page-nav" aria-label="Page navigation">
+      {%- if prev_page -%}
+        <a class="page-nav-link page-nav-prev" href="{{ prev_page.url | absolute_url }}" rel="prev">
+          <span class="page-nav-label">Previous</span>
+          <span class="page-nav-title">{{ prev_page.title }}</span>
+        </a>
+      {%- else -%}
+        <span class="page-nav-link page-nav-empty"></span>
+      {%- endif -%}
+      {%- if next_page -%}
+        <a class="page-nav-link page-nav-next" href="{{ next_page.url | absolute_url }}" rel="next">
+          <span class="page-nav-label">Next</span>
+          <span class="page-nav-title">{{ next_page.title }}</span>
+        </a>
+      {%- else -%}
+        <span class="page-nav-link page-nav-empty"></span>
+      {%- endif -%}
+    </nav>
+  {%- endif -%}
+{%- endif -%}

--- a/_includes/sort_pages.html
+++ b/_includes/sort_pages.html
@@ -1,0 +1,61 @@
+{%- comment -%}
+  Sorts `include.pages` into `pages_list` using the same rules as the sidebar
+  navigation (see nav.html). Shared by nav.html and page_nav.html so the
+  prev/next buttons follow the exact sidebar order.
+
+  The values of `title` and `nav_order` can be numbers or strings.
+  Jekyll gives build failures when sorting on mixtures of different types,
+  so numbers and strings need to be sorted separately.
+
+  Here, numbers are sorted by their values, and come before all strings.
+  An omitted `nav_order` value is equivalent to the page's `title` value
+  (except that a numerical `title` value is treated as a string).
+
+  The case-sensitivity of string sorting is determined by `site.nav_sort`.
+{%- endcomment -%}
+{%- assign included_pages = include.pages
+      | where_exp:"item", "item.nav_exclude != true"
+      | where_exp:"item", "item.title != nil" -%}
+
+{%- assign string_ordered_pages = included_pages
+      | where_exp:"item", "item.nav_order == nil" -%}
+{%- assign nav_ordered_pages = included_pages
+      | where_exp:"item", "item.nav_order != nil"  -%}
+
+{%- comment -%}
+  The nav_ordered_pages have to be added to number_ordered_pages and
+  string_ordered_pages, depending on the nav_order value.
+  The first character of the jsonify result is `"` only for strings.
+{%- endcomment -%}
+{%- assign nav_ordered_groups = nav_ordered_pages
+      | group_by_exp:"item", "item.nav_order | jsonify | slice: 0" -%}
+{%- assign number_ordered_pages = "" | split:"X" -%}
+{%- for group in nav_ordered_groups -%}
+  {%- if group.name == '"' -%}
+    {%- assign string_ordered_pages = string_ordered_pages | concat: group.items -%}
+  {%- else -%}
+    {%- assign number_ordered_pages = number_ordered_pages | concat: group.items -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- assign sorted_number_ordered_pages = number_ordered_pages | sort:"nav_order" -%}
+
+{%- comment -%}
+  The string_ordered_pages have to be sorted by nav_order, and otherwise title
+  (where appending the empty string to a numeric title converts it to a string).
+  After grouping them by those values, the groups are sorted, then the items
+  of each group are concatenated.
+{%- endcomment -%}
+{%- assign string_ordered_groups = string_ordered_pages
+      | group_by_exp:"item", "item.nav_order | default: item.title | append:''" -%}
+{%- if site.nav_sort == 'case_insensitive' -%}
+  {%- assign sorted_string_ordered_groups = string_ordered_groups | sort_natural:"name" -%}
+{%- else -%}
+  {%- assign sorted_string_ordered_groups = string_ordered_groups | sort:"name" -%}
+{%- endif -%}
+{%- assign sorted_string_ordered_pages = "" | split:"X" -%}
+{%- for group in sorted_string_ordered_groups -%}
+  {%- assign sorted_string_ordered_pages = sorted_string_ordered_pages | concat: group.items -%}
+{%- endfor -%}
+
+{%- assign pages_list = sorted_number_ordered_pages | concat: sorted_string_ordered_pages -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -139,7 +139,7 @@ layout: table_wrappers
         {% endunless %}
 
         {% if site.footer_content != nil or site.last_edit_timestamp %}
-          <hr>
+          {% if page.url == "/" %}<hr>{% endif %}
           <footer>
             <p style="text-align: left;" class="main-content">See an issue on this page ? Help us by fixing it <a href="https://github.com/ossia/score-docs/edit/master/{{ page.path }}">here</a> !</p>
             {% if site.back_to_top %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -134,6 +134,10 @@ layout: table_wrappers
           </ul>
         {% endif %}
 
+        {% unless page.url == "/" %}
+          {% include page_nav.html %}
+        {% endunless %}
+
         {% if site.footer_content != nil or site.last_edit_timestamp %}
           <hr>
           <footer>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -9,3 +9,61 @@
 video {
     max-width: 100%;
 }
+
+
+// Previous / Next page navigation buttons (see _includes/page_nav.html)
+.page-nav {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid $border-color;
+}
+
+.page-nav-link {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+    max-width: 48%;
+    padding: 0.6rem 0.9rem;
+    border: 1px solid $border-color;
+    border-radius: 4px;
+    text-decoration: none;
+    transition: border-color 150ms ease, background-color 150ms ease;
+
+    &:hover {
+        border-color: $link-color;
+        background-color: $sidebar-color;
+    }
+}
+
+.page-nav-empty {
+    border: none;
+    background: none;
+    pointer-events: none;
+}
+
+.page-nav-next {
+    text-align: right;
+    align-items: flex-end;
+}
+
+.page-nav-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: $grey-dk-100;
+}
+
+.page-nav-prev .page-nav-label::before {
+    content: "← ";
+}
+
+.page-nav-next .page-nav-label::after {
+    content: " →";
+}
+
+.page-nav-title {
+    font-weight: 500;
+}

--- a/docs/reference-manual/processes/library/accumulator.md
+++ b/docs/reference-manual/processes/library/accumulator.md
@@ -1,0 +1,40 @@
+---
+layout: default
+
+title: Accumulator
+description: "Accumulate running statistics (sum, mean, variance, …) of a value stream"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/accumulator.html
+---
+# Accumulator
+
+<!-- TODO screenshot: ![Accumulator]({{ site.img }}/reference/processes/accumulator.png "Accumulator") -->
+
+Keeps running statistics over the stream of numeric values it receives. Each time a new
+value comes in, every statistic is updated and emitted, so the Accumulator can drive other
+parameters from the behaviour of an input over time (e.g. smoothing, normalisation,
+analysis).
+
+## In
+
+The incoming `float` values to accumulate.
+
+## Reset
+
+A toggle that clears all accumulated statistics and starts over.
+
+## Outputs
+
+For the values received since the last reset:
+
+* **Sum** — total of all values.
+* **Count** — number of values received.
+* **Consecutive difference** — difference between the last two values.
+* **Mean** — running average.
+* **Variance** — running variance.
+* **Median** — running median.
+* **Kurtosis** — distribution shape.
+* **Min** / **Max** — smallest and largest values seen.

--- a/docs/reference-manual/processes/library/array-to-mesh.md
+++ b/docs/reference-manual/processes/library/array-to-mesh.md
@@ -1,0 +1,37 @@
+---
+layout: default
+
+title: Array to mesh
+description: "Build a mesh geometry from an array of floating-point values"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/array-to-mesh.html
+---
+# Array to mesh
+
+<!-- TODO screenshot: ![Array to mesh]({{ site.img }}/reference/processes/array-to-mesh.png "Array to mesh") -->
+
+Converts a flat array of floating-point values into a 3D mesh geometry. This is useful
+to turn computed or incoming numeric data (sensors, generative algorithms, audio
+analysis, etc.) into renderable geometry that can be fed to the 3D pipeline.
+
+## Input
+
+The list of `float` values to interpret as mesh data.
+
+## Triangulate
+
+When enabled, the incoming points are triangulated into a filled surface. When disabled,
+the data is kept as a raw point/line set.
+
+## Position / Rotation / Scale
+
+Standard transform controls applied to the resulting geometry before it is sent to the
+output.
+
+## Output
+
+A **Geometry** port that can be connected to any 3D process expecting a mesh
+(renderer, geometry filters, etc.).

--- a/docs/reference-manual/processes/library/array-to-texture.md
+++ b/docs/reference-manual/processes/library/array-to-texture.md
@@ -1,0 +1,37 @@
+---
+layout: default
+
+title: Array to texture
+description: "Pack an array of floating-point values into a GPU texture"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/array-to-texture.html
+---
+# Array to texture
+
+<!-- TODO screenshot: ![Array to texture]({{ site.img }}/reference/processes/array-to-texture.png "Array to texture") -->
+
+Packs a flat array of floating-point values into a GPU texture. This lets numeric data
+be uploaded to the graphics pipeline so it can be sampled by shaders, used as a
+displacement/lookup map, or visualised directly.
+
+## Input
+
+The list of `float` values to write into the texture.
+
+## Size
+
+The width and height (in pixels) of the generated texture. The input array is laid out
+to fill these dimensions.
+
+## Format
+
+The pixel format used to store the data (e.g. single-channel float, RGBA float, …).
+Choose the format that matches how the downstream shader will read the texture.
+
+## Output
+
+A **Texture** port connectable to any process consuming a texture (renderers, shaders,
+texture utilities).

--- a/docs/reference-manual/processes/library/automation.md
+++ b/docs/reference-manual/processes/library/automation.md
@@ -1,0 +1,46 @@
+---
+layout: default
+
+title: Automation
+description: "Send a value evolving along an editable curve over time"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/automation.html
+---
+# Automation
+
+<!-- TODO screenshot: ![Automation]({{ site.img }}/reference/processes/automation.png "Automation") -->
+
+The Automation is one of score's most fundamental processes. It outputs a single value that
+evolves along an editable curve for the duration of its parent interval — the classic way
+to animate a parameter over time.
+
+## The curve
+
+The curve is drawn in the process body and read from left (interval start) to right
+(interval end):
+
+* **Double-click** on the curve to add a point.
+* **Drag** points to shape the envelope.
+* **Drag a segment** to bend it; segments support several tween shapes (linear, power,
+  sine, …) via the right-click menu.
+
+The vertical axis is normalised between 0 and 1 and then remapped to the output range.
+
+## Min / Max
+
+The output range. The normalised curve value (0–1) is scaled so that 0 maps to **Min** and
+1 maps to **Max**. Set these to match the range of the parameter you are driving.
+
+## Address
+
+Drag a parameter from a [device](https://ossia.io/score-docs/devices/devices.html) onto the
+Automation, or onto the process, to bind the output directly to that address. The
+Automation will then write its evolving value to that parameter as the interval plays.
+
+## Output
+
+The current curve value, which can also be connected to other processes through the port
+on the process header.

--- a/docs/reference-manual/processes/library/buffer-queue.md
+++ b/docs/reference-manual/processes/library/buffer-queue.md
@@ -1,0 +1,41 @@
+---
+layout: default
+
+title: Buffer queue
+description: "Accumulate incoming messages and output them as a buffer"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/buffer-queue.html
+---
+# Buffer queue
+
+<!-- TODO screenshot: ![Buffer queue]({{ site.img }}/reference/processes/buffer-queue.png "Buffer queue") -->
+
+Accumulates the values it receives over time and exposes them as a buffer. Useful to
+build a history of recent values, to batch a stream of messages, or to turn a sequence of
+single values into a list.
+
+## Input
+
+The value to push into the queue.
+
+## Max length
+
+Maximum number of elements kept. When the queue is full, the oldest elements are dropped
+as new ones arrive (FIFO).
+
+## Mode / Data
+
+* **Mode** — how the queue behaves when emitting (e.g. emit on each input vs. on demand).
+* **Data** — how the stored values are formatted on the output.
+
+## Clear / Lock
+
+* **Clear** — empty the queue.
+* **Lock** — freeze the queue so new inputs are ignored.
+
+## Output
+
+The accumulated values as an `ossia::value` (typically a list).

--- a/docs/reference-manual/processes/library/buffers-to-geometry.md
+++ b/docs/reference-manual/processes/library/buffers-to-geometry.md
@@ -1,0 +1,49 @@
+---
+layout: default
+
+title: Buffers to geometry
+description: "Assemble GPU buffers into a renderable geometry"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/buffers-to-geometry.html
+---
+# Buffers to geometry
+
+<!-- TODO screenshot: ![Buffers to geometry]({{ site.img }}/reference/processes/buffers-to-geometry.png "Buffers to geometry") -->
+
+Assembles raw GPU buffers into a structured geometry that the renderer can draw. This is
+the low-level counterpart to the mesh loaders: you provide the vertex/index data as
+buffers and describe how to interpret them.
+
+## Buffer inputs
+
+Up to eight GPU buffer inputs can be connected (for example position, normal, colour,
+texture-coordinate streams produced by other processes).
+
+## Attribute specification
+
+For each attribute you describe how to read it from the buffers:
+
+* **Buffer** — which input buffer it comes from.
+* **Offset** / **Stride** — byte layout inside the buffer.
+* **Format** — component type and count.
+* **Semantic** — what the attribute represents (position, normal, …).
+* **Instanced** — whether the attribute advances per instance instead of per vertex.
+
+## Index buffer
+
+Optional index buffer configuration for indexed drawing.
+
+## Topology / Cull
+
+Primitive **topology** (triangles, lines, points, …) and face **culling** settings.
+
+## Transform
+
+Position, rotation and scale applied to the assembled geometry.
+
+## Output
+
+A **Geometry** port ready to be rendered or processed further.

--- a/docs/reference-manual/processes/library/extract-buffer.md
+++ b/docs/reference-manual/processes/library/extract-buffer.md
@@ -1,0 +1,36 @@
+---
+layout: default
+
+title: Extract buffer
+description: "Extract a single attribute buffer from a geometry"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/extract-buffer.html
+---
+# Extract buffer
+
+<!-- TODO screenshot: ![Extract buffer]({{ site.img }}/reference/processes/extract-buffer.png "Extract buffer") -->
+
+Pulls one attribute out of a geometry and exposes it as a standalone GPU buffer. This
+lets you take, for instance, just the vertex positions or normals of a mesh and feed them
+to another process for analysis or further processing.
+
+## Geometry
+
+The input geometry to read from.
+
+## Attribute
+
+Which attribute to extract (position, normal, colour, texture coordinates, …).
+
+## Pad vec3 to vec4
+
+When enabled, three-component attributes are padded to four components, which some GPU
+consumers require for correct alignment.
+
+## Output
+
+A **GPU buffer** containing the selected attribute. See also
+[Buffers to geometry](buffers-to-geometry.html) and [Repack attributes](repack-attributes.html).

--- a/docs/reference-manual/processes/library/geometry-info.md
+++ b/docs/reference-manual/processes/library/geometry-info.md
@@ -1,0 +1,32 @@
+---
+layout: default
+
+title: Geometry Info
+description: "Inspect the structure and metadata of a geometry"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/geometry-info.html
+---
+# Geometry Info
+
+<!-- TODO screenshot: ![Geometry Info]({{ site.img }}/reference/processes/geometry-info.png "Geometry Info") -->
+
+Reports metadata about an incoming geometry. Useful for debugging the 3D pipeline and for
+driving other processes from the actual size/shape of a mesh.
+
+## Geometry
+
+The geometry to inspect.
+
+## Outputs
+
+* **Vertices** — number of vertices.
+* **Indices** — number of indices.
+* **Instances** — number of instances.
+* **Attributes** — number of vertex attributes.
+* **Bindings** — number of buffer bindings.
+* **Inputs** — number of input buffers.
+* **Readable** — a human-readable string summarising the geometry, handy for display in a
+  [Text](text.html) process or a log.

--- a/docs/reference-manual/processes/library/javascript-presets.md
+++ b/docs/reference-manual/processes/library/javascript-presets.md
@@ -1,0 +1,33 @@
+---
+layout: default
+
+title: JavaScript presets
+description: "JavaScript/QML presets bundled with score"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript-presets.html
+---
+# JavaScript presets
+
+Ready-made JavaScript/QML scripts bundled in the score user library. Each can be loaded and edited live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+| Preset |
+|---|
+| [Painter]({{ site.baseurl }}/processes/javascript/painter.html) |
+| [Advanced Text]({{ site.baseurl }}/processes/javascript/advanced-text.html) |
+| [Average]({{ site.baseurl }}/processes/javascript/average.html) |
+| [Claves]({{ site.baseurl }}/processes/javascript/claves.html) |
+| [Euclidean Melody]({{ site.baseurl }}/processes/javascript/euclidean-melody.html) |
+| [FPS Camera]({{ site.baseurl }}/processes/javascript/fps-camera.html) |
+| [Gltf]({{ site.baseurl }}/processes/javascript/gltf.html) |
+| [JS 3D Example]({{ site.baseurl }}/processes/javascript/js-3d-example.html) |
+| [JS UI]({{ site.baseurl }}/processes/javascript/js-ui.html) |
+| [Presentation]({{ site.baseurl }}/processes/javascript/presentation.html) |
+| [Random Notes]({{ site.baseurl }}/processes/javascript/random-notes.html) |
+| [Read CSV]({{ site.baseurl }}/processes/javascript/read-csv.html) |
+| [Rect Mapper]({{ site.baseurl }}/processes/javascript/rect-mapper.html) |
+| [Sine]({{ site.baseurl }}/processes/javascript/sine.html) |
+| [Transpose]({{ site.baseurl }}/processes/javascript/transpose.html) |
+| [UI Example]({{ site.baseurl }}/processes/javascript/ui-example.html) |

--- a/docs/reference-manual/processes/library/javascript/advanced-text.md
+++ b/docs/reference-manual/processes/library/javascript/advanced-text.md
@@ -1,0 +1,21 @@
+---
+layout: default
+
+title: Advanced Text
+description: "JavaScript preset: Advanced Text"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/advanced-text.html
+---
+# Advanced Text
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/advanced-text.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- TextureInlet
+- TextureOutlet
+- ValueInlet ×2
+

--- a/docs/reference-manual/processes/library/javascript/advanced-text.md
+++ b/docs/reference-manual/processes/library/javascript/advanced-text.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Advanced Text"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/advanced-text.html
 ---

--- a/docs/reference-manual/processes/library/javascript/average.md
+++ b/docs/reference-manual/processes/library/javascript/average.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Average"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/average.html
 ---

--- a/docs/reference-manual/processes/library/javascript/average.md
+++ b/docs/reference-manual/processes/library/javascript/average.md
@@ -1,0 +1,24 @@
+---
+layout: default
+
+title: Average
+description: "JavaScript preset: Average"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/average.html
+---
+# Average
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/average.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- ValueInlet
+- ValueOutlet
+
+## Controls
+
+- milliseconds
+

--- a/docs/reference-manual/processes/library/javascript/claves.md
+++ b/docs/reference-manual/processes/library/javascript/claves.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Claves"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/claves.html
 ---

--- a/docs/reference-manual/processes/library/javascript/claves.md
+++ b/docs/reference-manual/processes/library/javascript/claves.md
@@ -1,0 +1,38 @@
+---
+layout: default
+
+title: Claves
+description: "JavaScript preset: Claves"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/claves.html
+---
+# Claves
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/claves.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- Impulse
+- ValueOutlet
+
+## Controls
+
+- C1 len
+- C1 gap
+- C1 note
+- C2 len
+- C2 gap
+- C2 note
+- C3 len
+- C3 gap
+- C3 note
+- C4 len
+- C4 gap
+- C4 note
+- C5 len
+- C5 gap
+- C5 note
+

--- a/docs/reference-manual/processes/library/javascript/euclidean-melody.md
+++ b/docs/reference-manual/processes/library/javascript/euclidean-melody.md
@@ -1,0 +1,35 @@
+---
+layout: default
+
+title: Euclidean Melody
+description: "JavaScript preset: Euclidean Melody"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/euclidean-melody.html
+---
+# Euclidean Melody
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/euclidean-melody.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- Impulse
+- ValueOutlet
+
+## Controls
+
+- root
+- da
+- db
+- dc
+- dd
+- de
+- e1a
+- e1b
+- e1c
+- e2a
+- e2b
+- e2c
+

--- a/docs/reference-manual/processes/library/javascript/euclidean-melody.md
+++ b/docs/reference-manual/processes/library/javascript/euclidean-melody.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Euclidean Melody"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/euclidean-melody.html
 ---

--- a/docs/reference-manual/processes/library/javascript/fps-camera.md
+++ b/docs/reference-manual/processes/library/javascript/fps-camera.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: FPS Camera"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/fps-camera.html
 ---

--- a/docs/reference-manual/processes/library/javascript/fps-camera.md
+++ b/docs/reference-manual/processes/library/javascript/fps-camera.md
@@ -1,0 +1,20 @@
+---
+layout: default
+
+title: FPS Camera
+description: "JavaScript preset: FPS Camera"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/fps-camera.html
+---
+# FPS Camera
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/fps-camera.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- ValueInlet ×2
+- ValueOutlet ×2
+

--- a/docs/reference-manual/processes/library/javascript/gltf.md
+++ b/docs/reference-manual/processes/library/javascript/gltf.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Gltf"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/gltf.html
 ---

--- a/docs/reference-manual/processes/library/javascript/gltf.md
+++ b/docs/reference-manual/processes/library/javascript/gltf.md
@@ -1,0 +1,19 @@
+---
+layout: default
+
+title: Gltf
+description: "JavaScript preset: Gltf"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/gltf.html
+---
+# Gltf
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/gltf.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- TextureOutlet
+

--- a/docs/reference-manual/processes/library/javascript/js-3d-example.md
+++ b/docs/reference-manual/processes/library/javascript/js-3d-example.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: JS 3D Example"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/js-3d-example.html
 ---

--- a/docs/reference-manual/processes/library/javascript/js-3d-example.md
+++ b/docs/reference-manual/processes/library/javascript/js-3d-example.md
@@ -1,0 +1,19 @@
+---
+layout: default
+
+title: JS 3D Example
+description: "JavaScript preset: JS 3D Example"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/js-3d-example.html
+---
+# JS 3D Example
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/js-3d-example.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- TextureOutlet
+

--- a/docs/reference-manual/processes/library/javascript/js-ui.md
+++ b/docs/reference-manual/processes/library/javascript/js-ui.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: JS UI"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/js-ui.html
 ---

--- a/docs/reference-manual/processes/library/javascript/js-ui.md
+++ b/docs/reference-manual/processes/library/javascript/js-ui.md
@@ -1,0 +1,19 @@
+---
+layout: default
+
+title: JS UI
+description: "JavaScript preset: JS UI"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/js-ui.html
+---
+# JS UI
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/js-ui.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- TextureOutlet
+

--- a/docs/reference-manual/processes/library/javascript/painter.md
+++ b/docs/reference-manual/processes/library/javascript/painter.md
@@ -1,0 +1,19 @@
+---
+layout: default
+
+title: Painter
+description: "JavaScript preset: Painter"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/painter.html
+---
+# Painter
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/Painter.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- TextureOutlet
+

--- a/docs/reference-manual/processes/library/javascript/painter.md
+++ b/docs/reference-manual/processes/library/javascript/painter.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Painter"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/painter.html
 ---

--- a/docs/reference-manual/processes/library/javascript/presentation.md
+++ b/docs/reference-manual/processes/library/javascript/presentation.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Presentation"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/presentation.html
 ---

--- a/docs/reference-manual/processes/library/javascript/presentation.md
+++ b/docs/reference-manual/processes/library/javascript/presentation.md
@@ -1,0 +1,20 @@
+---
+layout: default
+
+title: Presentation
+description: "JavaScript preset: Presentation"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/presentation.html
+---
+# Presentation
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/presentation.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- TextureInlet ×8
+- TextureOutlet
+

--- a/docs/reference-manual/processes/library/javascript/random-notes.md
+++ b/docs/reference-manual/processes/library/javascript/random-notes.md
@@ -1,0 +1,19 @@
+---
+layout: default
+
+title: Random Notes
+description: "JavaScript preset: Random Notes"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/random-notes.html
+---
+# Random Notes
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/random-notes.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- MidiOutlet
+

--- a/docs/reference-manual/processes/library/javascript/random-notes.md
+++ b/docs/reference-manual/processes/library/javascript/random-notes.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Random Notes"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/random-notes.html
 ---

--- a/docs/reference-manual/processes/library/javascript/read-csv.md
+++ b/docs/reference-manual/processes/library/javascript/read-csv.md
@@ -1,0 +1,19 @@
+---
+layout: default
+
+title: Read CSV
+description: "JavaScript preset: Read CSV"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/read-csv.html
+---
+# Read CSV
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/read-csv.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- ValueOutlet
+

--- a/docs/reference-manual/processes/library/javascript/read-csv.md
+++ b/docs/reference-manual/processes/library/javascript/read-csv.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Read CSV"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/read-csv.html
 ---

--- a/docs/reference-manual/processes/library/javascript/rect-mapper.md
+++ b/docs/reference-manual/processes/library/javascript/rect-mapper.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Rect Mapper"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/rect-mapper.html
 ---

--- a/docs/reference-manual/processes/library/javascript/rect-mapper.md
+++ b/docs/reference-manual/processes/library/javascript/rect-mapper.md
@@ -1,0 +1,21 @@
+---
+layout: default
+
+title: Rect Mapper
+description: "JavaScript preset: Rect Mapper"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/rect-mapper.html
+---
+# Rect Mapper
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/rect-mapper.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- TextureInlet ×8
+- TextureOutlet
+- ValueInlet
+

--- a/docs/reference-manual/processes/library/javascript/sine.md
+++ b/docs/reference-manual/processes/library/javascript/sine.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Sine"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/sine.html
 ---

--- a/docs/reference-manual/processes/library/javascript/sine.md
+++ b/docs/reference-manual/processes/library/javascript/sine.md
@@ -1,0 +1,23 @@
+---
+layout: default
+
+title: Sine
+description: "JavaScript preset: Sine"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/sine.html
+---
+# Sine
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/sine.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- AudioOutlet
+
+## Controls
+
+- Frequency
+

--- a/docs/reference-manual/processes/library/javascript/transpose.md
+++ b/docs/reference-manual/processes/library/javascript/transpose.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: Transpose"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/transpose.html
 ---

--- a/docs/reference-manual/processes/library/javascript/transpose.md
+++ b/docs/reference-manual/processes/library/javascript/transpose.md
@@ -1,0 +1,20 @@
+---
+layout: default
+
+title: Transpose
+description: "JavaScript preset: Transpose"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/transpose.html
+---
+# Transpose
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/transpose.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- MidiInlet
+- MidiOutlet
+

--- a/docs/reference-manual/processes/library/javascript/ui-example.md
+++ b/docs/reference-manual/processes/library/javascript/ui-example.md
@@ -1,0 +1,24 @@
+---
+layout: default
+
+title: UI Example
+description: "JavaScript preset: UI Example"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/javascript/ui-example.html
+---
+# UI Example
+
+A JavaScript/QML scripting preset from the [score user library](https://github.com/ossia/score-user-library) (`Presets/Javascript/ui-example.qml`). Edit the script live in the [JavaScript]({{ site.baseurl }}/processes/javascript.html) process.
+
+## Ports
+
+- ValueInlet
+- ValueOutlet
+
+## Controls
+
+- Control
+

--- a/docs/reference-manual/processes/library/javascript/ui-example.md
+++ b/docs/reference-manual/processes/library/javascript/ui-example.md
@@ -6,6 +6,7 @@ description: "JavaScript preset: UI Example"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/javascript/ui-example.html
 ---

--- a/docs/reference-manual/processes/library/librediffusion-generator.md
+++ b/docs/reference-manual/processes/library/librediffusion-generator.md
@@ -1,0 +1,36 @@
+---
+layout: default
+
+title: LibreDiffusion Generator
+description: "Real-time image generation through the LibreDiffusion backend"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/librediffusion-generator.html
+---
+# LibreDiffusion Generator
+
+<!-- TODO screenshot: ![LibreDiffusion Generator]({{ site.img }}/reference/processes/librediffusion-generator.png "LibreDiffusion Generator") -->
+
+Generates images in real time using the [LibreDiffusion](https://github.com/ossia)
+backend. It exposes the same StreamDiffusion workflow as the
+[StreamDiffusion](streamdiffusion.html) process — text-to-image and image-to-image on a
+texture stream — provided by the `score-addon-librediffusion` add-on.
+
+## Inputs
+
+* **Image** — input texture for image-to-image.
+* **Trigger** — run a generation step.
+* **Positive / negative prompt** — generation guidance.
+* **Engines path** — location of the installed diffusion engines.
+
+## Generation controls
+
+Seed, guidance scale, timesteps, resolution, CFG type, add-noise, denoising batch, manual
+mode, delta, and feed-previous-input/output — see [StreamDiffusion](streamdiffusion.html)
+for the full description of each control.
+
+## Output
+
+The generated **texture**.

--- a/docs/reference-manual/processes/library/ltc-generator.md
+++ b/docs/reference-manual/processes/library/ltc-generator.md
@@ -1,0 +1,37 @@
+---
+layout: default
+
+title: LTC Generator
+description: "Generate SMPTE Linear Timecode as an audio signal"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/ltc-generator.html
+---
+# LTC Generator
+
+<!-- TODO screenshot: ![LTC Generator]({{ site.img }}/reference/processes/ltc-generator.png "LTC Generator") -->
+
+Generates [SMPTE Linear Timecode (LTC)](https://en.wikipedia.org/wiki/Linear_timecode) as
+an audio signal, following score's transport position. Route the output to an audio device
+to synchronise external gear (recorders, lighting desks, DAWs) to your score.
+
+## Offset
+
+A time offset, in seconds, added to the generated timecode. Use it to align the emitted
+timecode with an external reference.
+
+## Framerate
+
+The timecode frame rate:
+
+* **525** — 30 fps (NTSC).
+* **625** — 25 fps (PAL).
+* **1125** — 30 fps (HD).
+* **Film** — 24 fps.
+
+## Output
+
+A single audio channel carrying the LTC signal. See also [LTC Input](ltc-input.html) for
+decoding incoming timecode.

--- a/docs/reference-manual/processes/library/ltc-input.md
+++ b/docs/reference-manual/processes/library/ltc-input.md
@@ -1,0 +1,50 @@
+---
+layout: default
+
+title: LTC Input
+description: "Decode SMPTE Linear Timecode from an audio signal"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/ltc-input.html
+---
+# LTC Input
+
+<!-- TODO screenshot: ![LTC Input]({{ site.img }}/reference/processes/ltc-input.png "LTC Input") -->
+
+Decodes [SMPTE Linear Timecode (LTC)](https://en.wikipedia.org/wiki/Linear_timecode) from
+an incoming audio signal, letting score follow an external timecode source. Feed it the
+audio channel carrying the LTC and read the decoded position from its outputs.
+
+## LTC audio
+
+The audio channel carrying the incoming LTC signal.
+
+## Offset
+
+A time offset, in seconds, applied to the decoded timecode.
+
+## Output format
+
+How the decoded timecode is presented on the **Timecode** output (e.g. seconds vs.
+HH:MM:SS:FF string).
+
+## Framerate
+
+Expected frame rate of the incoming timecode (must match the source).
+
+## Queue size
+
+Internal decoding buffer size; larger values are more robust but add latency.
+
+## Outputs
+
+* **Timecode** — the decoded position.
+* **Valid** — whether a valid signal is currently being decoded.
+* **Frame rate** — detected frame rate.
+* **Drop frame** — drop-frame flag.
+* **Reverse** — set when the source is playing backwards.
+* **Volume** — input signal level.
+
+See also [LTC Generator](ltc-generator.html).

--- a/docs/reference-manual/processes/library/mapping-utilities.md
+++ b/docs/reference-manual/processes/library/mapping-utilities.md
@@ -13,4 +13,26 @@ permalink: /processes/mapping-utilities.html
 
 ![Mapping utilities]({{ site.img }}/reference/processes/mapping-utilities.png "Mapping utilities") 
 
-Reference is not yet available. Feel more than welcome to ask for help on the [ossia.io forum](https://forum.ossia.io) or send a message on [ossia score Gitter channel](https://gitter.im/ossia/score) where you will most likely find a handful of *score* users and developers.
+A collection of small processes for mapping and transforming control values.
+
+## Counter
+
+<!-- TODO screenshot: ![Counter]({{ site.img }}/reference/processes/counter.png "Counter") -->
+
+Counts the messages or impulses it receives and outputs the running count. Useful to drive
+steps, indices or triggers from a stream of events.
+
+* **Increase** — each incoming message increments the counter.
+* **Output** — emit the current count on demand.
+* **Max** — ceiling value for the counter.
+* **Mode** — what happens when the count reaches **Max**:
+  * **Free** — keep counting past the maximum.
+  * **Clip** — stop at the maximum.
+  * **Wrap** — wrap back around to the start.
+  * **Fold** — bounce back down.
+
+Outputs the current **Count**, and fires a **Ceiling** event when the maximum is reached.
+
+---
+
+More reference is on its way. Feel more than welcome to ask for help on the [ossia.io forum](https://forum.ossia.io) or send a message on [ossia score Gitter channel](https://gitter.im/ossia/score) where you will most likely find a handful of *score* users and developers.

--- a/docs/reference-manual/processes/library/meshes.md
+++ b/docs/reference-manual/processes/library/meshes.md
@@ -1,0 +1,40 @@
+---
+layout: default
+
+title: Meshes
+description: "Generate and load 3D meshes: primitives, OBJ/PLY loader, noise, splats"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/meshes.html
+---
+# Meshes
+
+<!-- TODO screenshot: ![Meshes]({{ site.img }}/reference/processes/meshes.png "Meshes") -->
+
+A family of processes that produce or modify mesh geometry for the 3D pipeline. Each
+outputs a **Geometry** that can be rendered or fed to geometry utilities. All of them share
+**Position**, **Rotation** and **Scale** transform controls.
+
+## Mesh Primitive
+
+Generates a parametric primitive: **Plane**, **Cube**, **Sphere**, **Icosahedron**,
+**Cone**, **Cylinder** or **Torus**. Each primitive exposes its own parameters (subdivision,
+radius, …).
+
+## Object loader
+
+Loads a 3D model from an **OBJ** or **PLY** file. Drop a file on the **3D file** port; the
+process outputs the loaded mesh(es).
+
+## Splat loader
+
+Loads a [Gaussian splatting](https://en.wikipedia.org/wiki/Gaussian_splatting) model
+(3DGS) from a PLY file and outputs it as a GPU buffer for splat rendering.
+
+## Mesh Noise
+
+Deforms an incoming geometry with noise. Each axis (**X / Y / Z**) can be displaced using
+**None**, **Noise** or **Sine**, with an independent **Intensity** per axis. Connect a
+geometry to its input and route the output to a renderer.

--- a/docs/reference-manual/processes/library/midi-sync.md
+++ b/docs/reference-manual/processes/library/midi-sync.md
@@ -1,0 +1,42 @@
+---
+layout: default
+
+title: MIDI Sync Out
+description: "Send MIDI Clock, Start/Stop and MIDI Time Code to synchronise external gear"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/midi-sync.html
+---
+# MIDI Sync Out
+
+<!-- TODO screenshot: ![MIDI Sync Out]({{ site.img }}/reference/processes/midi-sync.png "MIDI Sync Out") -->
+
+Emits MIDI synchronisation messages so external instruments, sequencers and effects can
+follow score's transport. Connect the output to a MIDI device.
+
+## MIDI Clock
+
+Sends 24-ppqn MIDI Clock pulses. The mode control selects whether and how clock is
+emitted.
+
+## MIDI Start/Stop
+
+Sends transport Start, Continue and Stop messages.
+
+## MIDI TimeCode
+
+Sends MIDI Time Code (MTC). Use this for frame-accurate synchronisation with video gear.
+
+## MTC offset
+
+Time offset applied to the emitted MTC.
+
+## MTC framerate
+
+Frame rate used for MTC (24 / 25 / 29.97 / 30 fps).
+
+## Output
+
+A MIDI bus carrying the selected synchronisation messages.

--- a/docs/reference-manual/processes/library/repack-attributes.md
+++ b/docs/reference-manual/processes/library/repack-attributes.md
@@ -1,0 +1,41 @@
+---
+layout: default
+
+title: Repack attributes
+description: "Repack geometry attributes into a single interleaved buffer"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/repack-attributes.html
+---
+# Repack attributes
+
+<!-- TODO screenshot: ![Repack attributes]({{ site.img }}/reference/processes/repack-attributes.png "Repack attributes") -->
+
+Takes a geometry and repacks the chosen attributes into a single, interleaved GPU buffer
+with a predictable layout. This is useful when feeding geometry data to a custom shader or
+compute pass that expects a specific vertex layout.
+
+## Geometry
+
+The input geometry whose attributes will be repacked.
+
+## Attribute selection
+
+Choose which attributes to include in the packed buffer:
+
+* **Position**
+* **Normal**
+* **Color**
+* **TexCoord**
+* **Tangent**
+
+Only the selected attributes are written, in order, into the output buffer.
+
+## Outputs
+
+* **Buffer** — the interleaved GPU buffer.
+* **Stride** — the byte stride of one vertex in the packed buffer, needed to read it back.
+
+See also [Extract buffer](extract-buffer.html) and [Buffers to geometry](buffers-to-geometry.html).

--- a/docs/reference-manual/processes/library/shaders/basic/blend.md
+++ b/docs/reference-manual/processes/library/shaders/basic/blend.md
@@ -1,0 +1,88 @@
+---
+layout: default
+
+title: Basic shaders — Blend
+description: "Blend GLSL shader presets bundled with score"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/basic/blend.html
+---
+# Basic shaders — Blend
+
+These are ISF/GLSL shader presets bundled in the [score user library](https://github.com/ossia/score-user-library). Drop one in your timeline and press **F1** for the original author's documentation. The full set in this category:
+
+| Preset | Description |
+|---|---|
+| Angular |  |
+| Bounce |  |
+| Bow Tie Horizontal | Automatically converted from https://gl-transitions.com/ |
+| Bow Tie Vertical |  |
+| Burn |  |
+| Butterfly Wave Scrawler |  |
+| Circle Crop |  |
+| Circle Open |  |
+| Circle |  |
+| Color Phase |  |
+| Color Relookup |  |
+| Colour Distance |  |
+| Crazy Parametric Fun |  |
+| CrossZoom |  |
+| Crosshatch |  |
+| Crosswarp |  |
+| Directional Warp |  |
+| Directional Wipe |  |
+| Directional |  |
+| Displace | Simple Displace |
+| Displacement |  |
+| Doom Screen Transition |  |
+| Doorway |  |
+| Dreamy Zoom |  |
+| Dreamy | Automatically converted from https://gl-transitions.com/ |
+| Fade Color |  |
+| Fade Gray Scale |  |
+| Fade |  |
+| Film Burn |  |
+| Fly Eye |  |
+| Glitch Displace |  |
+| Glitch Memories |  |
+| Glitch Shifter |  |
+| Grid Flip |  |
+| Heart Transition |  |
+| Hexagonalize |  |
+| Inverted Page Curl | Automatically converted from https://gl-transitions.com/ |
+| Kaleidoscope Transition |  |
+| Linear Blur |  |
+| Luma Transition | Automatically converted from https://gl-transitions.com/ |
+| Luminance Melt |  |
+| Morph |  |
+| Mosaic |  |
+| Multiply Blend |  |
+| Perlin Transition |  |
+| Pinwheel |  |
+| Pixelize |  |
+| Polar Function |  |
+| Polka Dots Curtain |  |
+| Radial |  |
+| Random Squares |  |
+| Ripple Transition |  |
+| Rotate Scale Fade |  |
+| Simple Zoom Transition |  |
+| Squares Wire |  |
+| Squeeze |  |
+| Stereo Viewer |  |
+| Swap Transition |  |
+| Swirl |  |
+| TV Static |  |
+| Undulating Burn Out |  |
+| Water Drop |  |
+| Wind |  |
+| Window Blinds |  |
+| Window Slice |  |
+| Wipe Down | Automatically converted from https://gl-transitions.com/ |
+| Wipe Left |  |
+| Wipe Right |  |
+| Wipe Up |  |
+| Zoom In Circles |  |
+| cube |  |

--- a/docs/reference-manual/processes/library/shaders/basic/filter.md
+++ b/docs/reference-manual/processes/library/shaders/basic/filter.md
@@ -1,0 +1,152 @@
+---
+layout: default
+
+title: Basic shaders — Filter
+description: "Filter GLSL shader presets bundled with score"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/basic/filter.html
+---
+# Basic shaders — Filter
+
+These are ISF/GLSL shader presets bundled in the [score user library](https://github.com/ossia/score-user-library). Drop one in your timeline and press **F1** for the original author's documentation. The full set in this category:
+
+| Preset | Description |
+|---|---|
+| 3d Rotate | performs a 3d rotation |
+| 5-Color Gradient |  |
+| ASCII Art | ASCII Art |
+| Boxinator |  |
+| Bright |  |
+| Broken LCD | Broken LCD using value noise |
+| CMYK Halftone-Lookaround |  |
+| CMYK Halftone |  |
+| Channel Slide |  |
+| Chroma Key | Chroma Key |
+| Chroma Zoom |  |
+| Circle Warp | Warps an image to fit in a circle by fitting the height of the image to the height of a circle |
+| Circle Wrap Distortion | Wraps the video into a circular shape |
+| Circular Screen |  |
+| Collage |  |
+| Color Blowout |  |
+| Color Controls |  |
+| Color Invert | Inverts the RGB channels of the input |
+| Color Levels |  |
+| Color Monochrome |  |
+| Color Posterize |  |
+| Convergence |  |
+| Corner Color Tint | Tints the corners of the image in different colors. |
+| Crop and Feather | ISF crop adjustment created to replace VIDVOX Quartz Composer FX, includes four sided feathering |
+| Crosshatch | Crosshatch FX |
+| Cubic Warp |  |
+| Deinterlace |  |
+| Denoise | Reduces noise from a high-ISO camera feed using a bilateral filter. |
+| Diagonal Blur |  |
+| Diagonalize |  |
+| Dirty Lens | Value Noise |
+| Dither-Bayer | Bayer style dithering |
+| Doodler Overlay | Uses a virtual pen to draw colors on top of an image. |
+| Dot Screen |  |
+| Double Vision |  |
+| Dual Side Scroller And Flip |  |
+| Duotone |  |
+| Edge Blowout | Stretches the edges out a region of the video |
+| Edge Distort |  |
+| Edge Trace |  |
+| Edges |  |
+| Emboss |  |
+| Exposure Adjust |  |
+| False Color |  |
+| Flip H |  |
+| Flip V |  |
+| Frosted Glass |  |
+| Gamma Correction |  |
+| God Rays | adapted from https://github.com/neilmendoza/ofxPostProcessing/blob/master/src/GodRaysPass.cpp |
+| HQ2X | High-quality 2x pixel art upscaler that preserves detail and creates smooth edges |
+| HSVtoRGB | swizzles RGBA to BGRA and vice versa |
+| Halftone Multi |  |
+| Hatch Blur |  |
+| Highlighter Overlay | Draws a highlighting bounding box on top of the input image. |
+| Histogram Viewer | Draws an RGB histogram from a provided histogram image |
+| Hyperspace |  |
+| Kaleidoscope Tile |  |
+| Kaleidoscope |  |
+| LGG | Performs a Lift Gamma Gain Saturation CDL |
+| Line Screen |  |
+| Luma Key | Luma Key FX |
+| Luminance Posterize |  |
+| Maximum Component |  |
+| Meta Image |  |
+| Minimum Component |  |
+| Mirror Edge |  |
+| Mirror |  |
+| Multi Gradient |  |
+| Multi Hue Shift | Performs hue shifts of different amounts depending on brightness levels |
+| MultiSharpen | Multi-tool for sharpening images |
+| Neon | adapted from https://github.com/neilmendoza/ofxPostProcessing/blob/master/src/GodRaysPass.cpp |
+| Noise Displace | Displaces image randomly |
+| Pattern Glitch | Applies randomized effects to different parts of the image. |
+| Pixel Shifter | Shifts pixels up and down |
+| Poly Glitch |  |
+| Posterize | Posterizes an image |
+| Power Warp | Power curves distortions with shifting |
+| Quad Mask |  |
+| Quad Tile |  |
+| RGB EQ |  |
+| RGB Halftone-lookaround |  |
+| RGB Halftone |  |
+| RGB Invert |  |
+| RGBA Swap |  |
+| RGBtoHSV | swizzles RGBA to BGRA and vice versa |
+| Radial Replicate | Repllcates a radial slice of an image |
+| Random Squares Mask |  |
+| Replicate Random |  |
+| Replicate |  |
+| Resize Glitch |  |
+| Sepia Tone |  |
+| Set Alpha | Sets the alpha channel of the image |
+| Shake |  |
+| Shape Mask |  |
+| Shape Morph Wrap | Wraps an image into a shape that is created by morphing two primitive shapes together |
+| Sharpen Luminance |  |
+| Sharpen RGB |  |
+| Shockwave |  |
+| Show Alpha | Maps the alpha to grayscale |
+| Side Scroller And Flip |  |
+| Sine Warp Tile |  |
+| Sketch |  |
+| Sliding Strips |  |
+| Slit Scan Mask | Pixels update only if within range of the specified lines to create a slit scan style |
+| Smoke Screen | A smoke screen overlay effect |
+| Soft Flip |  |
+| Solarize | Solarizes an image |
+| Sorting Smear |  |
+| Sphere Map | Maps video onto a sphere |
+| Strojobal |  |
+| Stylize Glitch | Applies randomized effects to different parts of the image. |
+| Thermal Camera |  |
+| Trapezoid Distortion | Warps the video into a trapezoid shape |
+| Triangle Warp | Warps an image to fit in a triangle by fitting the height of the image to the height of a triangle |
+| Trio Tone |  |
+| Triple Rotate | Performs three different rotations |
+| Twirl |  |
+| Unsharp Mask |  |
+| VHS Glitch | VHS Glitch Style |
+| Vertex Manipulator | Moves the vertex points to the specified locations without correction |
+| Vibrance |  |
+| Video Bricks | Tiles the incoming image using a basic brick pattern |
+| Video Snake | Makes a grid of frame delayed images |
+| White Point Adjust | Modifies the white point by multiplying the src pixel by the color value |
+| XYZoom |  |
+| Zoom |  |
+| v002 Bleach Bypass |  |
+| v002 Crosshatch |  |
+| v002 Dilate | messed up version of v002 dilate |
+| v002 Erode | messed up version of v002 erode |
+| v002 Glitch Analog | Emulates classic analog video interference, distortion and sync issues. |
+| v002 Light Leak |  |
+| v002 Technicolor |  |
+| v002 Vignette |  |
+| v002-CRT-Displacement | CRT Displacement, emulating the look of curved CRT Displays |

--- a/docs/reference-manual/processes/library/shaders/basic/generator.md
+++ b/docs/reference-manual/processes/library/shaders/basic/generator.md
@@ -1,0 +1,63 @@
+---
+layout: default
+
+title: Basic shaders — Generator
+description: "Generator GLSL shader presets bundled with score"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/basic/generator.html
+---
+# Basic shaders — Generator
+
+These are ISF/GLSL shader presets bundled in the [score user library](https://github.com/ossia/score-user-library). Drop one in your timeline and press **F1** for the original author's documentation. The full set in this category:
+
+| Preset | Description |
+|---|---|
+| Audio Waveform Shape | Wraps an audio waveform around a shape and does video feedback. |
+| Basic Shape |  |
+| BitStreamer |  |
+| Bloboscillator | based on https://www.shadertoy.com/view/MlKXWm by cacheflowe.  A wannabe reaction-diffusion, but not at all :-P |
+| Brick Pattern | Generates a basic brick pattern |
+| Checkerboard |  |
+| Color Bars |  |
+| Color Organ Polyphonic |  |
+| Color Scales |  |
+| Color Schemes | Creates variations on a base color using a given algorithm. |
+| Color Test Grid |  |
+| Corner Colors | Generates a gradient that fades between four different colors. |
+| CrossGrid |  |
+| Doodler | Uses a virtual pen to draw colors with a random walk. |
+| Fractal Dots |  |
+| GOTO10 |  |
+| Graph Paper | Draws basic graph paper pattern |
+| Heart |  |
+| Kaleidolines |  |
+| Line Group | Draws a series of lines at different angles along a line. |
+| Linear Gradient |  |
+| Lines |  |
+| Linescape |  |
+| Liquid Fire |  |
+| ParticleZoom |  |
+| Perlin Noise | generates a basic perlin noise |
+| Poly Star |  |
+| Radial Gradient |  |
+| Random Characters | Drawing random characters from a font encoded as an array. |
+| Random Checkerboard | Creates a checkerboard pattern with randomized colors |
+| Random Lines |  |
+| Random Shape |  |
+| Random Stripes | Creates a stripe pattern with randomized colors |
+| Simplex Noise | generates a basic simplex noise |
+| Sine Warp Gradient |  |
+| Solid Color | demonstrates the use of color-type image inputs |
+| Spiral |  |
+| Star |  |
+| Stripes |  |
+| SumDotz |  |
+| Triangle Square Twist |  |
+| Triangle |  |
+| Truchet Tile | Creates a Truchet Tile pattern |
+| Turbulent Shapes |  |
+| Voronoi Cell Noise | generates a basic voronoi cell noise |
+| White Noise | generates a basic white noise |

--- a/docs/reference-manual/processes/library/shaders/basic/multipass.md
+++ b/docs/reference-manual/processes/library/shaders/basic/multipass.md
@@ -1,0 +1,85 @@
+---
+layout: default
+
+title: Basic shaders — Multipass
+description: "Multipass GLSL shader presets bundled with score"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/basic/multipass.html
+---
+# Basic shaders — Multipass
+
+These are ISF/GLSL shader presets bundled in the [score user library](https://github.com/ossia/score-user-library). Drop one in your timeline and press **F1** for the original author's documentation. The full set in this category:
+
+| Preset | Description |
+|---|---|
+| Auto Color Tone | Creates variations on a base color using a given algorithm. |
+| Auto Colors Histogram |  |
+| Auto Levels | Auto Levels |
+| Bloom |  |
+| Chroma Desaturation Mask |  |
+| Chroma Mask |  |
+| Circle Trails |  |
+| Circular Feedback Mask |  |
+| City Lights |  |
+| Color Blowout |  |
+| Color History | Displays Data Over Time |
+| Color Replacement |  |
+| Comet Tails | This does a feedback motion blur based on the brightness of pixels to create an analog recording comet trails effect |
+| Digital Clock | Shows the current time of day or time since the composition started |
+| Dilate-Fast |  |
+| Dilate |  |
+| Duotone From Histogram | Adjusts an image to use colors determined from a histogram |
+| Echo Trace | Pixel with brightness levels below the threshold do not update. |
+| Edge Blur |  |
+| Erode-Fast |  |
+| Erode |  |
+| Etch-a-Sketch | Draw images one pixel at a time |
+| FFT Spectrogram | Buffers the incoming FFTs for timed display |
+| Fast Blur |  |
+| FastMosh | Does a fast faked data-mosh style |
+| Flipbook | Creates a flipbook like effect |
+| Freeze Frame | Holds the output on the captured freeze frame |
+| Ghosting |  |
+| Gloom |  |
+| Glow-Fast |  |
+| Glow |  |
+| HorizVertHold |  |
+| Interlace |  |
+| Key Frame Artifacts | Keeps an accumulation of difference since a key frame |
+| Lens Flare |  |
+| Life | Based on Conway Game of Life |
+| Long Exposure | Bright objects burn in and optionally decay |
+| Micro Buffer RGB | Buffers 8 recent frames |
+| Micro Buffer | Buffers 8 recent frames |
+| Motion Heat Map | Shows where there is motion between frames |
+| Motion Mask | Masks an image based on the amount of motion |
+| Multi Pass Gaussian Blur | Performs a deep blur |
+| MultiFrame 2x2 | buffers the last 3 frames and draws a 2x2 grid of the 4 current frames available |
+| MultiFrame 3x3 | buffers the last 3 frames and draws a 2x2 grid of the 4 current frames available |
+| Noise Adapt | Pixels that change become noise until they match the input again |
+| Optical Flow Distort | Uses an optical flow mask to create a distortion |
+| Optical Flow Generator | Creates a raw optical flow mask from the input image |
+| RE RGB Gradient Generator |  |
+| RGB Strobe |  |
+| RGB Trails 3.0 | a persistent buffer is used to maintain an image which is constantly updated.  Similar to VVMotionBlur, but each channel has its own weight |
+| Radial Spectrogram | Generates a radial audiospectrogram from fft-input |
+| Random Freeze | Causes only part of an image to update |
+| Random Shape Blast |  |
+| Saturation Bleed | Applies a blur to the saturation levels of pixels. |
+| Shape Morph Feedback Mask |  |
+| Shockwave Pulse |  |
+| Slit Scan | Pixels update only if within range of the specified lines to create a slit scan style |
+| Smudged Lens | Blurs parts of an image as if the lens is smudged |
+| Soft Blur |  |
+| Sorting Smear |  |
+| Strobe |  |
+| Time Glitch RGB | Buffers 8 recent frames |
+| Trail Mask | Pixels update only based on the masking image |
+| VVMotionBlur 3.0 | this is basically identical to the demonstration of a persistent buffer |
+| Vertical Tearing | This introduces a vertical tearing effect similar to when GL VBL sync is off. |
+| Waveform Displace | Displaces image with audio waveform |
+| Y-C Time Blur | This converts to YIQ and does separate feedback blur on the Y and C channels |
+| Zooming Feedback | Creates a simple zooming feedback loop |

--- a/docs/reference-manual/processes/library/shaders/fulldome.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome.md
@@ -1,0 +1,27 @@
+---
+layout: default
+
+title: Fulldome shaders
+description: "Shaders for fulldome / 360° workflows: cubemap, equirectangular and domemaster format conversions, bundled in the score user library."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/fulldome.html
+---
+# Fulldome shaders
+
+Shaders for fulldome / 360° workflows: cubemap, equirectangular and domemaster format conversions, bundled in the score user library.
+
+| Preset | Description |
+|---|---|
+| [Video Mixer Dome]({{ site.baseurl }}/processes/shaders/fulldome/video-mixer-dome.html) | 8-channel video mixer with Aspect Ratio control |
+| [Cubemap]({{ site.baseurl }}/processes/shaders/fulldome/cubemap.html) | Arranges six input cube face images into a selectable layout (Horizontal Strip, Vertical Cross, or Horizontal Cross). Each face can be individually rotated by 0, 90, 180, or 270 degrees clockwise. Defines standard cell mappings for each layout type. Empty cells in cross layouts are transparent black. Assumes input faces are standard 2D views. |
+| [Cubemap To Equirectangular]({{ site.baseurl }}/processes/shaders/fulldome/cubemap-to-equirectangular.html) | Converts a cubemap atlas (strip or cross layout) to an equirectangular image. Requires knowing the layout and any rotations applied to faces in the atlas. |
+| [Cubesides To Domemaster]({{ site.baseurl }}/processes/shaders/fulldome/cubesides-to-domemaster.html) | Generates a Domemaster output by projecting a rotated cubemap (6 input images). Rotations and output FOV are controllable. |
+| [Domemaster Mask]({{ site.baseurl }}/processes/shaders/fulldome/domemaster-mask.html) | Applies a customizable Domemaster mask defined by a polar angle range, a color, and a feathered edge (softness). Assumes the input is a 210-degree FOV Domemaster projection. |
+| [Equirectangular To Cubemap]({{ site.baseurl }}/processes/shaders/fulldome/equirectangular-to-cubemap.html) | Converts an equirectangular image to a cubemap atlas (strip or cross layout). Allows for applying rotations to each face. |
+| [Equirectangular To Domemaster]({{ site.baseurl }}/processes/shaders/fulldome/equirectangular-to-domemaster.html) | Generates a Domemaster output by projecting a rotated equirectangular image. Rotations, output FOV, and horizontal flip are controllable. |
+| [Half Cubesides To Domemaster]({{ site.baseurl }}/processes/shaders/fulldome/half-cubesides-to-domemaster.html) | Optimized single-pass Domemaster. Maps raw 2:1 images to top/bottom halves, rotating bottom 180. Includes API-level input flips. |
+| [Hexagonal Faces To Domemaster]({{ site.baseurl }}/processes/shaders/fulldome/hexagonal-faces-to-domemaster.html) | Hexagonal Prism Domemaster. 6 side faces (split into top/bottom halves, bottom rotated 180) + 2 pole faces. Preserves transparency. |
+| [Image To Equirectangular]({{ site.baseurl }}/processes/shaders/fulldome/image-to-equirectangular.html) | Overlays an image onto an equirectangular projection with true spherical distortion. Allows 3D positioning, rotation, and scaling of the overlay on the sphere. Surrounding space is transparent or shows a base equirectangular image. |

--- a/docs/reference-manual/processes/library/shaders/fulldome/cubemap-to-equirectangular.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/cubemap-to-equirectangular.md
@@ -1,0 +1,35 @@
+---
+layout: default
+
+title: Cubemap To Equirectangular
+description: "Converts a cubemap atlas (strip or cross layout) to an equirectangular image. Requires knowing the layout and any rotations applied to faces in the atlas."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/fulldome/cubemap-to-equirectangular.html
+---
+# Cubemap To Equirectangular
+
+<!-- TODO screenshot: ![Cubemap To Equirectangular]({{ site.img }}/reference/processes/shaders/fulldome/cubemap-to-equirectangular.png "Cubemap To Equirectangular") -->
+
+Converts a cubemap atlas (strip or cross layout) to an equirectangular image. Requires knowing the layout and any rotations applied to faces in the atlas.
+
+_Fulldome / 360° conversion shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Cubemap Atlas Texture | image | input texture |
+| Input Atlas Layout | long | options: Horizontal Strip (6w x 1h), Vertical Cross (3w x 4h), Horizontal Cross (4w x 3h) |
+| Atlas +X Original Rotation | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Atlas -X Original Rotation | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Atlas +Y Original Rotation | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Atlas -Y Original Rotation | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Atlas +Z Original Rotation | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Atlas -Z Original Rotation | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+
+## Credit
+
+Edu Meneses + AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/fulldome/cubemap-to-equirectangular.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/cubemap-to-equirectangular.md
@@ -6,6 +6,7 @@ description: "Converts a cubemap atlas (strip or cross layout) to an equirectang
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/fulldome/cubemap-to-equirectangular.html
 ---

--- a/docs/reference-manual/processes/library/shaders/fulldome/cubemap.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/cubemap.md
@@ -6,6 +6,7 @@ description: "Arranges six input cube face images into a selectable layout (Hori
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/fulldome/cubemap.html
 ---

--- a/docs/reference-manual/processes/library/shaders/fulldome/cubemap.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/cubemap.md
@@ -1,0 +1,40 @@
+---
+layout: default
+
+title: Cubemap
+description: "Arranges six input cube face images into a selectable layout (Horizontal Strip, Vertical Cross, or Horizontal Cross). Each face can be individually rotated by 0, 90, 180, or 270 degrees clockwise. Defines standard cell mappings for each layout type. Empty cells in cross layouts are transparent black. Assumes input faces are standard 2D views."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/fulldome/cubemap.html
+---
+# Cubemap
+
+<!-- TODO screenshot: ![Cubemap]({{ site.img }}/reference/processes/shaders/fulldome/cubemap.png "Cubemap") -->
+
+Arranges six input cube face images into a selectable layout (Horizontal Strip, Vertical Cross, or Horizontal Cross). Each face can be individually rotated by 0, 90, 180, or 270 degrees clockwise. Defines standard cell mappings for each layout type. Empty cells in cross layouts are transparent black. Assumes input faces are standard 2D views.
+
+_Fulldome / 360° conversion shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Face +X (Right) | image | input texture |
+| Face -X (Left) | image | input texture |
+| Face +Y (Top) | image | input texture |
+| Face -Y (Bottom) | image | input texture |
+| Face +Z (Front) | image | input texture |
+| Face -Z (Back) | image | input texture |
+| Output Layout | long | options: Horizontal Strip (6w x 1h), Vertical Cross (3w x 4h), Horizontal Cross (4w x 3h) |
+| Rotate +X (Right) | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Rotate -X (Left) | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Rotate +Y (Top) | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Rotate -Y (Bottom) | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Rotate +Z (Front) | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Rotate -Z (Back) | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+
+## Credit
+
+Edu Meneses + AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/fulldome/cubesides-to-domemaster.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/cubesides-to-domemaster.md
@@ -6,6 +6,7 @@ description: "Generates a Domemaster output by projecting a rotated cubemap (6 i
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/fulldome/cubesides-to-domemaster.html
 ---

--- a/docs/reference-manual/processes/library/shaders/fulldome/cubesides-to-domemaster.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/cubesides-to-domemaster.md
@@ -1,0 +1,37 @@
+---
+layout: default
+
+title: Cubesides To Domemaster
+description: "Generates a Domemaster output by projecting a rotated cubemap (6 input images). Rotations and output FOV are controllable."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/fulldome/cubesides-to-domemaster.html
+---
+# Cubesides To Domemaster
+
+<!-- TODO screenshot: ![Cubesides To Domemaster]({{ site.img }}/reference/processes/shaders/fulldome/cubesides-to-domemaster.png "Cubesides To Domemaster") -->
+
+Generates a Domemaster output by projecting a rotated cubemap (6 input images). Rotations and output FOV are controllable.
+
+_Fulldome / 360° conversion shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Face +X (Right) | image | input texture |
+| Face -X (Left) | image | input texture |
+| Face +Y (Top) | image | input texture |
+| Face -Y (Bottom) | image | input texture |
+| Face +Z (Front) | image | input texture |
+| Face -Z (Back) | image | input texture |
+| Rotate X (0-1, Yaw) | float | range 0.0–1.0, default 0.5 |
+| Rotate Y (0-1, Pitch) | float | range 0.0–1.0, default 0.5 |
+| Rotate Z (0-1, Roll) | float | range 0.0–1.0, default 0.5 |
+| Domemaster Output FOV (degrees) | float | range 1.0–360.0, default 180.0 |
+
+## Credit
+
+Edu Meneses + AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/fulldome/domemaster-mask.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/domemaster-mask.md
@@ -6,6 +6,7 @@ description: "Applies a customizable Domemaster mask defined by a polar angle ra
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/fulldome/domemaster-mask.html
 ---

--- a/docs/reference-manual/processes/library/shaders/fulldome/domemaster-mask.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/domemaster-mask.md
@@ -1,0 +1,32 @@
+---
+layout: default
+
+title: Domemaster Mask
+description: "Applies a customizable Domemaster mask defined by a polar angle range, a color, and a feathered edge (softness). Assumes the input is a 210-degree FOV Domemaster projection."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/fulldome/domemaster-mask.html
+---
+# Domemaster Mask
+
+<!-- TODO screenshot: ![Domemaster Mask]({{ site.img }}/reference/processes/shaders/fulldome/domemaster-mask.png "Domemaster Mask") -->
+
+Applies a customizable Domemaster mask defined by a polar angle range, a color, and a feathered edge (softness). Assumes the input is a 210-degree FOV Domemaster projection.
+
+_Fulldome / 360° conversion shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Domemaster Input | image | input texture |
+| Keep 1:1 Input Aspect | bool | default True |
+| Mask Polar Angle Degrees (0 to 60) | float | range 0.0–60.0, default 14.0 |
+| Mask Softness (Feathering Degrees) | float | range 0.0–30.0, default 1.0 |
+| Mask Color (incl. Alpha) | color | colour |
+
+## Credit
+
+AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/fulldome/equirectangular-to-cubemap.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/equirectangular-to-cubemap.md
@@ -6,6 +6,7 @@ description: "Converts an equirectangular image to a cubemap atlas (strip or cro
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/fulldome/equirectangular-to-cubemap.html
 ---

--- a/docs/reference-manual/processes/library/shaders/fulldome/equirectangular-to-cubemap.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/equirectangular-to-cubemap.md
@@ -1,0 +1,35 @@
+---
+layout: default
+
+title: Equirectangular To Cubemap
+description: "Converts an equirectangular image to a cubemap atlas (strip or cross layout). Allows for applying rotations to each face."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/fulldome/equirectangular-to-cubemap.html
+---
+# Equirectangular To Cubemap
+
+<!-- TODO screenshot: ![Equirectangular To Cubemap]({{ site.img }}/reference/processes/shaders/fulldome/equirectangular-to-cubemap.png "Equirectangular To Cubemap") -->
+
+Converts an equirectangular image to a cubemap atlas (strip or cross layout). Allows for applying rotations to each face.
+
+_Fulldome / 360° conversion shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Equirectangular Image | image | input texture |
+| Output Atlas Layout | long | options: Horizontal Strip (6w x 1h), Vertical Cross (3w x 4h), Horizontal Cross (4w x 3h) |
+| Apply Rotation to +X Face | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Apply Rotation to -X Face | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Apply Rotation to +Y Face | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Apply Rotation to -Y Face | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Apply Rotation to +Z Face | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+| Apply Rotation to -Z Face | long | options: 0 deg, 90 deg CW, 180 deg, 270 deg CW |
+
+## Credit
+
+Edu Meneses + AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/fulldome/equirectangular-to-domemaster.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/equirectangular-to-domemaster.md
@@ -6,6 +6,7 @@ description: "Generates a Domemaster output by projecting a rotated equirectangu
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/fulldome/equirectangular-to-domemaster.html
 ---

--- a/docs/reference-manual/processes/library/shaders/fulldome/equirectangular-to-domemaster.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/equirectangular-to-domemaster.md
@@ -1,0 +1,31 @@
+---
+layout: default
+
+title: Equirectangular To Domemaster
+description: "Generates a Domemaster output by projecting a rotated equirectangular image. Rotations, output FOV, and horizontal flip are controllable."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/fulldome/equirectangular-to-domemaster.html
+---
+# Equirectangular To Domemaster
+
+<!-- TODO screenshot: ![Equirectangular To Domemaster]({{ site.img }}/reference/processes/shaders/fulldome/equirectangular-to-domemaster.png "Equirectangular To Domemaster") -->
+
+Generates a Domemaster output by projecting a rotated equirectangular image. Rotations, output FOV, and horizontal flip are controllable.
+
+_Fulldome / 360° conversion shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Equirectangular Input | image | input texture |
+| XYZrotate | point3D |  |
+| Domemaster Output FOV (degrees) | float | range 1.0–360.0, default 180.0 |
+| Flip Horizontally (Ext. Surface) | bool | default False |
+
+## Credit
+
+Edu Meneses + AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/fulldome/half-cubesides-to-domemaster.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/half-cubesides-to-domemaster.md
@@ -1,0 +1,45 @@
+---
+layout: default
+
+title: Half Cubesides To Domemaster
+description: "Optimized single-pass Domemaster. Maps raw 2:1 images to top/bottom halves, rotating bottom 180. Includes API-level input flips."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/fulldome/half-cubesides-to-domemaster.html
+---
+# Half Cubesides To Domemaster
+
+<!-- TODO screenshot: ![Half Cubesides To Domemaster]({{ site.img }}/reference/processes/shaders/fulldome/half-cubesides-to-domemaster.png "Half Cubesides To Domemaster") -->
+
+Optimized single-pass Domemaster. Maps raw 2:1 images to top/bottom halves, rotating bottom 180. Includes API-level input flips.
+
+_Fulldome / 360° conversion shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| +X Side (Top Image) | image | input texture |
+| +X Side (Bottom Image - 180 Rot) | image | input texture |
+| -X Side (Top Image) | image | input texture |
+| -X Side (Bottom Image - 180 Rot) | image | input texture |
+| +Z Side (Front Top) | image | input texture |
+| +Z Side (Front Bottom - 180 Rot) | image | input texture |
+| -Z Side (Back Top) | image | input texture |
+| -Z Side (Back Bottom - 180 Rot) | image | input texture |
+| +Y Pole (Zenith/Ceiling) | image | input texture |
+| -Y Pole (Nadir/Floor) | image | input texture |
+| Alpha (Top Imgs) | float | range 0.0–1.0, default 1.0 |
+| Alpha (Bottom Imgs) | float | range 0.0–1.0, default 1.0 |
+| Rotate X (0-1, Yaw) | float | range 0.0–1.0, default 0.5 |
+| Rotate Y (0-1, Pitch) | float | range 0.0–1.0, default 0.5 |
+| Rotate Z (0-1, Roll) | float | range 0.0–1.0, default 0.5 |
+| Domemaster Output FOV | float | range 1.0–360.0, default 180.0 |
+| Flip Inputs Horizontally | bool | default False |
+| Flip Inputs Vertically (GL/VK) | bool | default False |
+
+## Credit
+
+Edu Meneses + AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/fulldome/half-cubesides-to-domemaster.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/half-cubesides-to-domemaster.md
@@ -6,6 +6,7 @@ description: "Optimized single-pass Domemaster. Maps raw 2:1 images to top/botto
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/fulldome/half-cubesides-to-domemaster.html
 ---

--- a/docs/reference-manual/processes/library/shaders/fulldome/hexagonal-faces-to-domemaster.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/hexagonal-faces-to-domemaster.md
@@ -1,0 +1,49 @@
+---
+layout: default
+
+title: Hexagonal Faces To Domemaster
+description: "Hexagonal Prism Domemaster. 6 side faces (split into top/bottom halves, bottom rotated 180) + 2 pole faces. Preserves transparency."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/fulldome/hexagonal-faces-to-domemaster.html
+---
+# Hexagonal Faces To Domemaster
+
+<!-- TODO screenshot: ![Hexagonal Faces To Domemaster]({{ site.img }}/reference/processes/shaders/fulldome/hexagonal-faces-to-domemaster.png "Hexagonal Faces To Domemaster") -->
+
+Hexagonal Prism Domemaster. 6 side faces (split into top/bottom halves, bottom rotated 180) + 2 pole faces. Preserves transparency.
+
+_Fulldome / 360° conversion shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Side 1 Top (0°) | image | input texture |
+| Side 1 Bot (0° - 180 Rot) | image | input texture |
+| Side 2 Top (60°) | image | input texture |
+| Side 2 Bot (60° - 180 Rot) | image | input texture |
+| Side 3 Top (120°) | image | input texture |
+| Side 3 Bot (120° - 180 Rot) | image | input texture |
+| Side 4 Top (180°) | image | input texture |
+| Side 4 Bot (180° - 180 Rot) | image | input texture |
+| Side 5 Top (240°) | image | input texture |
+| Side 5 Bot (240° - 180 Rot) | image | input texture |
+| Side 6 Top (300°) | image | input texture |
+| Side 6 Bot (300° - 180 Rot) | image | input texture |
+| Top Pole (+Y Zenith) | image | input texture |
+| Bottom Pole (-Y Nadir) | image | input texture |
+| Alpha (Top Imgs) | float | range 0.0–1.0, default 1.0 |
+| Alpha (Bottom Imgs) | float | range 0.0–1.0, default 1.0 |
+| Rotate X (0-1, Yaw) | float | range 0.0–1.0, default 0.5 |
+| Rotate Y (0-1, Pitch) | float | range 0.0–1.0, default 0.5 |
+| Rotate Z (0-1, Roll) | float | range 0.0–1.0, default 0.5 |
+| Domemaster Output FOV | float | range 1.0–360.0, default 180.0 |
+| Flip Inputs Horizontally | bool | default False |
+| Flip Inputs Vertically (GL/VK) | bool | default False |
+
+## Credit
+
+Edu Meneses + AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/fulldome/hexagonal-faces-to-domemaster.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/hexagonal-faces-to-domemaster.md
@@ -6,6 +6,7 @@ description: "Hexagonal Prism Domemaster. 6 side faces (split into top/bottom ha
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/fulldome/hexagonal-faces-to-domemaster.html
 ---

--- a/docs/reference-manual/processes/library/shaders/fulldome/image-to-equirectangular.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/image-to-equirectangular.md
@@ -6,6 +6,7 @@ description: "Overlays an image onto an equirectangular projection with true sph
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/fulldome/image-to-equirectangular.html
 ---

--- a/docs/reference-manual/processes/library/shaders/fulldome/image-to-equirectangular.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/image-to-equirectangular.md
@@ -1,0 +1,35 @@
+---
+layout: default
+
+title: Image To Equirectangular
+description: "Overlays an image onto an equirectangular projection with true spherical distortion. Allows 3D positioning, rotation, and scaling of the overlay on the sphere. Surrounding space is transparent or shows a base equirectangular image."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/fulldome/image-to-equirectangular.html
+---
+# Image To Equirectangular
+
+<!-- TODO screenshot: ![Image To Equirectangular]({{ site.img }}/reference/processes/shaders/fulldome/image-to-equirectangular.png "Image To Equirectangular") -->
+
+Overlays an image onto an equirectangular projection with true spherical distortion. Allows 3D positioning, rotation, and scaling of the overlay on the sphere. Surrounding space is transparent or shows a base equirectangular image.
+
+_Fulldome / 360° conversion shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Background Equirectangular (Optional) | image | input texture |
+| Overlay Image | image | input texture |
+| Center Longitude (deg) | float | range -180.0–180.0, default 0.0 |
+| Center Latitude (deg) | float | range -90.0–90.0, default 0.0 |
+| Overlay Width (deg) | float | range 0.1–360.0, default 90.0 |
+| Overlay Height (deg) | float | range 0.1–180.0, default 90.0 |
+| Rotation (deg) | float | range -360.0–360.0, default 0.0 |
+| Overlay Alpha | float | range 0.0–1.0, default 1.0 |
+
+## Credit
+
+Edu Meneses + AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/fulldome/video-mixer-dome.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/video-mixer-dome.md
@@ -6,6 +6,7 @@ description: "8-channel video mixer with Aspect Ratio control"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/fulldome/video-mixer-dome.html
 ---

--- a/docs/reference-manual/processes/library/shaders/fulldome/video-mixer-dome.md
+++ b/docs/reference-manual/processes/library/shaders/fulldome/video-mixer-dome.md
@@ -1,0 +1,51 @@
+---
+layout: default
+
+title: Video Mixer Dome
+description: "8-channel video mixer with Aspect Ratio control"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/fulldome/video-mixer-dome.html
+---
+# Video Mixer Dome
+
+<!-- TODO screenshot: ![Video Mixer Dome]({{ site.img }}/reference/processes/shaders/fulldome/video-mixer-dome.png "Video Mixer Dome") -->
+
+8-channel video mixer with Aspect Ratio control
+
+_Fulldome / 360° conversion shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Texture 1 | image | input texture |
+| Texture 2 | image | input texture |
+| Texture 3 | image | input texture |
+| Texture 4 | image | input texture |
+| Texture 5 | image | input texture |
+| Texture 6 | image | input texture |
+| Texture 7 | image | input texture |
+| Texture 8 | image | input texture |
+| Keep 1:1 Input Aspect | bool | default True |
+| Alpha 1 | float | range 0–1, default 1 |
+| Alpha 2 | float | range 0–1, default 0 |
+| Alpha 3 | float | range 0–1, default 0 |
+| Alpha 4 | float | range 0–1, default 0 |
+| Alpha 5 | float | range 0–1, default 0 |
+| Alpha 6 | float | range 0–1, default 0 |
+| Alpha 7 | float | range 0–1, default 0 |
+| Alpha 8 | float | range 0–1, default 0 |
+| Mode 1 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 2 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 3 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 4 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 5 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 6 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 7 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+
+## Credit
+
+Original code by Jamie Owen and Jean-Michaël Celerier. optimizations and dome version Edu Meneses + AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/utility.md
+++ b/docs/reference-manual/processes/library/shaders/utility.md
@@ -1,0 +1,31 @@
+---
+layout: default
+
+title: Utility shaders
+description: "Helper GLSL shaders for compositing, cropping, masking and routing video, bundled in the score user library."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility.html
+---
+# Utility shaders
+
+Helper GLSL shaders for compositing, cropping, masking and routing video, bundled in the score user library.
+
+| Preset | Description |
+|---|---|
+| [Crop Edges]({{ site.baseurl }}/processes/shaders/utility/crop-edges.html) | Crop an image by its left, right, bottom, and top edges. The cropped region is remapped to fill the output |
+| [Crop]({{ site.baseurl }}/processes/shaders/utility/crop.html) | Crop a normalized rectangle from the input image and stretch it to the output. Two modes: Center+Size or Corners. |
+| [Grid]({{ site.baseurl }}/processes/shaders/utility/grid.html) | Display up to 16 image inputs in a mosaic grid for previsualization. The grid layout adapts automatically to the number of active inputs. |
+| [Layer]({{ site.baseurl }}/processes/shaders/utility/layer.html) | Layer videos on top of each other. First texture is at the bottom. |
+| [Mask]({{ site.baseurl }}/processes/shaders/utility/mask.html) | Apply a mask |
+| [Passthrough]({{ site.baseurl }}/processes/shaders/utility/passthrough.html) | Copy the input texture without changes |
+| [Tiny Date Time Overlay]({{ site.baseurl }}/processes/shaders/utility/tiny-date-time-overlay.html) | Draws a small (80x48 pixel) time / date stamp. |
+| [Transform]({{ site.baseurl }}/processes/shaders/utility/transform.html) | 2D image transform with translate, rotate, scale, pivot, tiling, and edge extend modes. |
+| [Video Mapper]({{ site.baseurl }}/processes/shaders/utility/video-mapper.html) | Moves the vertex points to the specified locations without correction |
+| [Video Mixer]({{ site.baseurl }}/processes/shaders/utility/video-mixer.html) | 8-channel video mixer (Optimized) |
+| [Video Switcher 16]({{ site.baseurl }}/processes/shaders/utility/video-switcher-16.html) | Video switcher |
+| [Video Switcher 4]({{ site.baseurl }}/processes/shaders/utility/video-switcher-4.html) | Video switcher |
+| [Video Switcher 8]({{ site.baseurl }}/processes/shaders/utility/video-switcher-8.html) | Video switcher |
+| [image_editor]({{ site.baseurl }}/processes/shaders/utility/image-editor.html) | Transforms an input image: scale, rotate (positive angle for CW image rotation), flip, and position. |

--- a/docs/reference-manual/processes/library/shaders/utility/crop-edges.md
+++ b/docs/reference-manual/processes/library/shaders/utility/crop-edges.md
@@ -6,6 +6,7 @@ description: "Crop an image by its left, right, bottom, and top edges. The cropp
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/crop-edges.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/crop-edges.md
+++ b/docs/reference-manual/processes/library/shaders/utility/crop-edges.md
@@ -1,0 +1,33 @@
+---
+layout: default
+
+title: Crop Edges
+description: "Crop an image by its left, right, bottom, and top edges. The cropped region is remapped to fill the output"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/crop-edges.html
+---
+# Crop Edges
+
+<!-- TODO screenshot: ![Crop Edges]({{ site.img }}/reference/processes/shaders/utility/crop-edges.png "Crop Edges") -->
+
+Crop an image by its left, right, bottom, and top edges. The cropped region is remapped to fill the output
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| inputImage | image | input texture |
+| Crop Left | float | range -0.5–1.5, default 0.0 |
+| Crop Right | float | range -0.5–1.5, default 1.0 |
+| Crop Bottom | float | range -0.5–1.5, default 0.0 |
+| Crop Top | float | range -0.5–1.5, default 1.0 |
+| Extend | long | options: Hold, Zero, Repeat, Mirror |
+
+## Credit
+
+ossia score

--- a/docs/reference-manual/processes/library/shaders/utility/crop.md
+++ b/docs/reference-manual/processes/library/shaders/utility/crop.md
@@ -6,6 +6,7 @@ description: "Crop a normalized rectangle from the input image and stretch it to
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/crop.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/crop.md
+++ b/docs/reference-manual/processes/library/shaders/utility/crop.md
@@ -1,0 +1,35 @@
+---
+layout: default
+
+title: Crop
+description: "Crop a normalized rectangle from the input image and stretch it to the output. Two modes: Center+Size or Corners."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/crop.html
+---
+# Crop
+
+<!-- TODO screenshot: ![Crop]({{ site.img }}/reference/processes/shaders/utility/crop.png "Crop") -->
+
+Crop a normalized rectangle from the input image and stretch it to the output. Two modes: Center+Size or Corners.
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| inputImage | image | input texture |
+| Mode | long | options: Center/Size, Corners |
+| center | point2D | 2D point |
+| width | float | range 0.0–1.0, default 0.5 |
+| height | float | range 0.0–1.0, default 0.5 |
+| topLeft | point2D | 2D point |
+| bottomRight | point2D | 2D point |
+| bgColor | color | colour |
+
+## Credit
+
+Jean-Michaël Celerier

--- a/docs/reference-manual/processes/library/shaders/utility/grid.md
+++ b/docs/reference-manual/processes/library/shaders/utility/grid.md
@@ -6,6 +6,7 @@ description: "Display up to 16 image inputs in a mosaic grid for previsualizatio
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/grid.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/grid.md
+++ b/docs/reference-manual/processes/library/shaders/utility/grid.md
@@ -1,0 +1,47 @@
+---
+layout: default
+
+title: Grid
+description: "Display up to 16 image inputs in a mosaic grid for previsualization. The grid layout adapts automatically to the number of active inputs."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/grid.html
+---
+# Grid
+
+<!-- TODO screenshot: ![Grid]({{ site.img }}/reference/processes/shaders/utility/grid.png "Grid") -->
+
+Display up to 16 image inputs in a mosaic grid for previsualization. The grid layout adapts automatically to the number of active inputs.
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Texture 1 | image | input texture |
+| Texture 2 | image | input texture |
+| Texture 3 | image | input texture |
+| Texture 4 | image | input texture |
+| Texture 5 | image | input texture |
+| Texture 6 | image | input texture |
+| Texture 7 | image | input texture |
+| Texture 8 | image | input texture |
+| Texture 9 | image | input texture |
+| Texture 10 | image | input texture |
+| Texture 11 | image | input texture |
+| Texture 12 | image | input texture |
+| Texture 13 | image | input texture |
+| Texture 14 | image | input texture |
+| Texture 15 | image | input texture |
+| Texture 16 | image | input texture |
+| Layout | long | options: Grid, Row, Column |
+| Input Count | long | default 4 |
+| Gap | float | range 0.0–0.05, default 0.005 |
+| Background | color | colour |
+
+## Credit
+
+ossia score

--- a/docs/reference-manual/processes/library/shaders/utility/image-editor.md
+++ b/docs/reference-manual/processes/library/shaders/utility/image-editor.md
@@ -6,6 +6,7 @@ description: "Transforms an input image: scale, rotate (positive angle for CW im
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/image-editor.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/image-editor.md
+++ b/docs/reference-manual/processes/library/shaders/utility/image-editor.md
@@ -1,0 +1,33 @@
+---
+layout: default
+
+title: image_editor
+description: "Transforms an input image: scale, rotate (positive angle for CW image rotation), flip, and position."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/image-editor.html
+---
+# image_editor
+
+<!-- TODO screenshot: ![image_editor]({{ site.img }}/reference/processes/shaders/utility/image-editor.png "image_editor") -->
+
+Transforms an input image: scale, rotate (positive angle for CW image rotation), flip, and position.
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| inputImage | image | input texture |
+| Rotation Angle (Degrees) | float | range -360.0–360.0, default 0.0 |
+| Scale Factor | float | range 0.01–10.0, default 1.0 |
+| Flip Horizontal | bool | default False |
+| Flip Vertical | bool | default False |
+| XYposition | point2D | 2D point |
+
+## Credit
+
+Edu Meneses + AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/utility/layer.md
+++ b/docs/reference-manual/processes/library/shaders/utility/layer.md
@@ -1,0 +1,35 @@
+---
+layout: default
+
+title: Layer
+description: "Layer videos on top of each other. First texture is at the bottom."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/layer.html
+---
+# Layer
+
+<!-- TODO screenshot: ![Layer]({{ site.img }}/reference/processes/shaders/utility/layer.png "Layer") -->
+
+Layer videos on top of each other. First texture is at the bottom.
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Texture 1 | image | input texture |
+| Texture 2 | image | input texture |
+| Texture 3 | image | input texture |
+| Texture 4 | image | input texture |
+| Texture 5 | image | input texture |
+| Texture 6 | image | input texture |
+| Texture 7 | image | input texture |
+| Texture 8 | image | input texture |
+
+## Credit
+
+Jean-Michaël Celerier

--- a/docs/reference-manual/processes/library/shaders/utility/layer.md
+++ b/docs/reference-manual/processes/library/shaders/utility/layer.md
@@ -6,6 +6,7 @@ description: "Layer videos on top of each other. First texture is at the bottom.
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/layer.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/mask.md
+++ b/docs/reference-manual/processes/library/shaders/utility/mask.md
@@ -1,0 +1,29 @@
+---
+layout: default
+
+title: Mask
+description: "Apply a mask"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/mask.html
+---
+# Mask
+
+<!-- TODO screenshot: ![Mask]({{ site.img }}/reference/processes/shaders/utility/mask.png "Mask") -->
+
+Apply a mask
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Texture 1 | image | input texture |
+| Texture 2 | image | input texture |
+
+## Credit
+
+ Jean-Michaël Celerier

--- a/docs/reference-manual/processes/library/shaders/utility/mask.md
+++ b/docs/reference-manual/processes/library/shaders/utility/mask.md
@@ -6,6 +6,7 @@ description: "Apply a mask"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/mask.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/passthrough.md
+++ b/docs/reference-manual/processes/library/shaders/utility/passthrough.md
@@ -1,0 +1,28 @@
+---
+layout: default
+
+title: Passthrough
+description: "Copy the input texture without changes"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/passthrough.html
+---
+# Passthrough
+
+<!-- TODO screenshot: ![Passthrough]({{ site.img }}/reference/processes/shaders/utility/passthrough.png "Passthrough") -->
+
+Copy the input texture without changes
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| inputImage | image | input texture |
+
+## Credit
+
+ossia score

--- a/docs/reference-manual/processes/library/shaders/utility/passthrough.md
+++ b/docs/reference-manual/processes/library/shaders/utility/passthrough.md
@@ -6,6 +6,7 @@ description: "Copy the input texture without changes"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/passthrough.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/tiny-date-time-overlay.md
+++ b/docs/reference-manual/processes/library/shaders/utility/tiny-date-time-overlay.md
@@ -6,6 +6,7 @@ description: "Draws a small (80x48 pixel) time / date stamp."
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/tiny-date-time-overlay.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/tiny-date-time-overlay.md
+++ b/docs/reference-manual/processes/library/shaders/utility/tiny-date-time-overlay.md
@@ -1,0 +1,34 @@
+---
+layout: default
+
+title: Tiny Date Time Overlay
+description: "Draws a small (80x48 pixel) time / date stamp."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/tiny-date-time-overlay.html
+---
+# Tiny Date Time Overlay
+
+<!-- TODO screenshot: ![Tiny Date Time Overlay]({{ site.img }}/reference/processes/shaders/utility/tiny-date-time-overlay.png "Tiny Date Time Overlay") -->
+
+Draws a small (80x48 pixel) time / date stamp.
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| inputImage | image | input texture |
+| charColor | color | colour |
+| bgColor | color | colour |
+| 24 Hours | bool | default 0 |
+| Month First | bool | default 1 |
+| Show at top | bool | default 0 |
+| Show on right | bool | default 1 |
+
+## Credit
+
+VIDVOX

--- a/docs/reference-manual/processes/library/shaders/utility/transform.md
+++ b/docs/reference-manual/processes/library/shaders/utility/transform.md
@@ -6,6 +6,7 @@ description: "2D image transform with translate, rotate, scale, pivot, tiling, a
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/transform.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/transform.md
+++ b/docs/reference-manual/processes/library/shaders/utility/transform.md
@@ -1,0 +1,41 @@
+---
+layout: default
+
+title: Transform
+description: "2D image transform with translate, rotate, scale, pivot, tiling, and edge extend modes."
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/transform.html
+---
+# Transform
+
+<!-- TODO screenshot: ![Transform]({{ site.img }}/reference/processes/shaders/utility/transform.png "Transform") -->
+
+2D image transform with translate, rotate, scale, pivot, tiling, and edge extend modes.
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| inputImage | image | input texture |
+| Transform Order | long | options: SRT, STR, RST, RTS, TSR, TRS |
+| Translate | point2D | 2D point |
+| Rotate | float | range -360.0–360.0, default 0.0 |
+| Scale | point2D | 2D point |
+| Grow / Shrink (px) | point2D | 2D point |
+| Pivot | point2D | 2D point |
+| Background Color | color | colour |
+| Pre-Multiply RGB by Alpha | bool | default False |
+| Comp Over Background | bool | default False |
+| Extend Mode | long | options: Hold, Zero, Repeat, Mirror |
+| Limit Tiles | bool | default False |
+| Tile U (Left, Right) | point2D | 2D point |
+| Tile V (Bottom, Top) | point2D | 2D point |
+
+## Credit
+
+ossia score

--- a/docs/reference-manual/processes/library/shaders/utility/video-mapper.md
+++ b/docs/reference-manual/processes/library/shaders/utility/video-mapper.md
@@ -6,6 +6,7 @@ description: "Moves the vertex points to the specified locations without correct
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/video-mapper.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/video-mapper.md
+++ b/docs/reference-manual/processes/library/shaders/utility/video-mapper.md
@@ -1,0 +1,34 @@
+---
+layout: default
+
+title: Video Mapper
+description: "Moves the vertex points to the specified locations without correction"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/video-mapper.html
+---
+# Video Mapper
+
+<!-- TODO screenshot: ![Video Mapper]({{ site.img }}/reference/processes/shaders/utility/video-mapper.png "Video Mapper") -->
+
+Moves the vertex points to the specified locations without correction
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| inputImage | image | input texture |
+| Top Left | point2D | 2D point |
+| Bottom Left | point2D | 2D point |
+| Top Right | point2D | 2D point |
+| Bottom Right | point2D | 2D point |
+| Translation | point2D | 2D point |
+| Scale | point2D | 2D point |
+
+## Credit
+
+VIDVOX

--- a/docs/reference-manual/processes/library/shaders/utility/video-mixer.md
+++ b/docs/reference-manual/processes/library/shaders/utility/video-mixer.md
@@ -6,6 +6,7 @@ description: "8-channel video mixer (Optimized)"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/video-mixer.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/video-mixer.md
+++ b/docs/reference-manual/processes/library/shaders/utility/video-mixer.md
@@ -1,0 +1,50 @@
+---
+layout: default
+
+title: Video Mixer
+description: "8-channel video mixer (Optimized)"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/video-mixer.html
+---
+# Video Mixer
+
+<!-- TODO screenshot: ![Video Mixer]({{ site.img }}/reference/processes/shaders/utility/video-mixer.png "Video Mixer") -->
+
+8-channel video mixer (Optimized)
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Texture 1 | image | input texture |
+| Texture 2 | image | input texture |
+| Texture 3 | image | input texture |
+| Texture 4 | image | input texture |
+| Texture 5 | image | input texture |
+| Texture 6 | image | input texture |
+| Texture 7 | image | input texture |
+| Texture 8 | image | input texture |
+| Alpha 1 | float | range 0–1, default 1 |
+| Alpha 2 | float | range 0–1, default 0 |
+| Alpha 3 | float | range 0–1, default 0 |
+| Alpha 4 | float | range 0–1, default 0 |
+| Alpha 5 | float | range 0–1, default 0 |
+| Alpha 6 | float | range 0–1, default 0 |
+| Alpha 7 | float | range 0–1, default 0 |
+| Alpha 8 | float | range 0–1, default 0 |
+| Mode 1 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 2 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 3 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 4 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 5 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 6 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+| Mode 7 | long | options: Add, Average, Color Burn, Color Dodge, Darken, Difference, Exclusion, Glow, Hard Light, Hard Mix, Lighten, Linear Burn, Linear Dodge, Linear Light, Multiply, Negation, Normal, Overlay, Phoenix, Pin Light, Reflect, Screen, Soft Light, Subtract, Vivid Light |
+
+## Credit
+
+Jamie Owen, Jean-Michaël Celerier, Optimized by AI Assistant (Gemini)

--- a/docs/reference-manual/processes/library/shaders/utility/video-switcher-16.md
+++ b/docs/reference-manual/processes/library/shaders/utility/video-switcher-16.md
@@ -6,6 +6,7 @@ description: "Video switcher"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/video-switcher-16.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/video-switcher-16.md
+++ b/docs/reference-manual/processes/library/shaders/utility/video-switcher-16.md
@@ -1,0 +1,44 @@
+---
+layout: default
+
+title: Video Switcher 16
+description: "Video switcher"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/video-switcher-16.html
+---
+# Video Switcher 16
+
+<!-- TODO screenshot: ![Video Switcher 16]({{ site.img }}/reference/processes/shaders/utility/video-switcher-16.png "Video Switcher 16") -->
+
+Video switcher
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Texture 0 | image | input texture |
+| Texture 1 | image | input texture |
+| Texture 2 | image | input texture |
+| Texture 3 | image | input texture |
+| Texture 4 | image | input texture |
+| Texture 5 | image | input texture |
+| Texture 6 | image | input texture |
+| Texture 7 | image | input texture |
+| Texture 8 | image | input texture |
+| Texture 9 | image | input texture |
+| Texture 10 | image | input texture |
+| Texture 11 | image | input texture |
+| Texture 12 | image | input texture |
+| Texture 13 | image | input texture |
+| Texture 14 | image | input texture |
+| Texture 15 | image | input texture |
+| Index | long | default 0 |
+
+## Credit
+
+Jean-Michaël Celerier

--- a/docs/reference-manual/processes/library/shaders/utility/video-switcher-4.md
+++ b/docs/reference-manual/processes/library/shaders/utility/video-switcher-4.md
@@ -6,6 +6,7 @@ description: "Video switcher"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/video-switcher-4.html
 ---

--- a/docs/reference-manual/processes/library/shaders/utility/video-switcher-4.md
+++ b/docs/reference-manual/processes/library/shaders/utility/video-switcher-4.md
@@ -1,0 +1,32 @@
+---
+layout: default
+
+title: Video Switcher 4
+description: "Video switcher"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/video-switcher-4.html
+---
+# Video Switcher 4
+
+<!-- TODO screenshot: ![Video Switcher 4]({{ site.img }}/reference/processes/shaders/utility/video-switcher-4.png "Video Switcher 4") -->
+
+Video switcher
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Texture 0 | image | input texture |
+| Texture 1 | image | input texture |
+| Texture 2 | image | input texture |
+| Texture 3 | image | input texture |
+| Index | long | default 0 |
+
+## Credit
+
+Jean-Michaël Celerier

--- a/docs/reference-manual/processes/library/shaders/utility/video-switcher-8.md
+++ b/docs/reference-manual/processes/library/shaders/utility/video-switcher-8.md
@@ -1,0 +1,36 @@
+---
+layout: default
+
+title: Video Switcher 8
+description: "Video switcher"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/shaders/utility/video-switcher-8.html
+---
+# Video Switcher 8
+
+<!-- TODO screenshot: ![Video Switcher 8]({{ site.img }}/reference/processes/shaders/utility/video-switcher-8.png "Video Switcher 8") -->
+
+Video switcher
+
+_Utility shader from the score user library._
+
+## Controls
+
+| Control | Type | Details |
+|---|---|---|
+| Texture 0 | image | input texture |
+| Texture 1 | image | input texture |
+| Texture 2 | image | input texture |
+| Texture 3 | image | input texture |
+| Texture 4 | image | input texture |
+| Texture 5 | image | input texture |
+| Texture 6 | image | input texture |
+| Texture 7 | image | input texture |
+| Index | long | default 0 |
+
+## Credit
+
+Jean-Michaël Celerier

--- a/docs/reference-manual/processes/library/shaders/utility/video-switcher-8.md
+++ b/docs/reference-manual/processes/library/shaders/utility/video-switcher-8.md
@@ -6,6 +6,7 @@ description: "Video switcher"
 
 parent: Processes
 grand_parent: Reference
+nav_exclude: true
 
 permalink: /processes/shaders/utility/video-switcher-8.html
 ---

--- a/docs/reference-manual/processes/library/streamdiffusion.md
+++ b/docs/reference-manual/processes/library/streamdiffusion.md
@@ -1,0 +1,55 @@
+---
+layout: default
+
+title: StreamDiffusion
+description: "Real-time image generation with StreamDiffusion (text-to-image, image-to-image)"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/streamdiffusion.html
+---
+# StreamDiffusion
+
+<!-- TODO screenshot: ![StreamDiffusion]({{ site.img }}/reference/processes/streamdiffusion.png "StreamDiffusion") -->
+
+Real-time diffusion-based image generation inside score. It can run text-to-image and
+image-to-image workflows on a texture stream, making it possible to transform live video
+or generate visuals on the fly. Requires the appropriate diffusion engines to be
+installed (see **Engines path**).
+
+## Image / Trigger
+
+* **Image** — input texture used for image-to-image workflows.
+* **Trigger** — fire a generation step.
+
+## Workflow
+
+Selects the generation mode (text-to-image, image-to-image, …).
+
+## Prompts
+
+* **Positive prompt** — what to generate.
+* **Negative prompt** — what to avoid.
+
+## Engines path
+
+Path to the installed diffusion engines/models.
+
+## Generation controls
+
+* **Seed** — random seed for reproducibility.
+* **Guidance scale** — prompt adherence strength.
+* **Timesteps** — number of diffusion steps.
+* **Resolution** — output size.
+* **CFG type** / **Delta** — classifier-free guidance settings.
+* **Add noise** / **Denoising batch** — denoising behaviour.
+* **Manual mode** — step manually instead of continuously.
+* **Feed previous input / output** — feed the previous frame back for temporal coherence.
+
+## Output
+
+The generated **texture**.
+
+> See also [LibreDiffusion Generator](librediffusion-generator.html), the LibreDiffusion
+> backend for this process.

--- a/docs/reference-manual/processes/library/synthimi.md
+++ b/docs/reference-manual/processes/library/synthimi.md
@@ -1,0 +1,56 @@
+---
+layout: default
+
+title: Synthimi
+description: "A polyphonic four-oscillator MIDI synthesizer"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/synthimi.html
+---
+# Synthimi
+
+<!-- TODO screenshot: ![Synthimi]({{ site.img }}/reference/processes/synthimi.png "Synthimi") -->
+
+A built-in polyphonic synthesizer driven by MIDI. It combines four oscillators, an
+amplitude and filter envelope, a multimode filter and a modulation matrix, and outputs
+stereo audio.
+
+## MIDI input
+
+Notes and controllers come in on the MIDI bus.
+
+## Oscillators 1–4
+
+Each oscillator has its own:
+
+* **Amplitude**
+* **Waveform**
+* **Pitch** and **Octave**
+
+## Envelopes
+
+* **Amp ADSR** — attack/decay/sustain/release for the amplitude.
+* **Filter ADSR** — envelope applied to the filter (enable with the filter-envelope
+  toggle).
+
+## Filter
+
+* **Type** — filter mode.
+* **Cutoff** and **Resonance**.
+
+## Voicing
+
+* **Polyphony mode** — how many simultaneous voices.
+* **Portamento** — glide time between notes.
+* **Unison** — stack detuned voices for a thicker sound.
+
+## Drive / Modulation
+
+* **Drive** — output saturation.
+* **Modulation matrix** — route modulation sources to destinations.
+
+## Output
+
+A fixed stereo audio output.

--- a/docs/reference-manual/processes/library/table.md
+++ b/docs/reference-manual/processes/library/table.md
@@ -1,0 +1,49 @@
+---
+layout: default
+
+title: Table
+description: "Store and recall arbitrary data in 1D, 2D or N-dimensional tables"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/table.html
+---
+# Table
+
+<!-- TODO screenshot: ![Table]({{ site.img }}/reference/processes/table.png "Table") -->
+
+Stores arbitrary values in an addressable table and lets you read, write, resize and clear
+them at runtime. Tables are handy as scratch memory, lookup tables, step sequencers or
+small datasets driven by other processes.
+
+Three variants are available:
+
+* **Table** — N-dimensional table.
+* **Table (1D)** — one-dimensional table (a simple list).
+* **Table (2D)** — two-dimensional table (a grid).
+
+## Writing
+
+* **Set cell / pair** — write a value at a given index (or key/value pair).
+* **Fill** — fill the whole table with a value.
+* **Resize / Dimensions** — change the table size or shape.
+* **Clear** — empty the table.
+
+## Reading
+
+* **Read** — request the value(s) at an index, emitted on the output.
+
+## Lock / Preserve / Dump
+
+* **Lock** — prevent further writes.
+* **Preserve** — keep the table content across resizes when possible.
+* **Dump** — emit the full table content.
+
+## Outputs
+
+* **Output** — the value(s) read from the table.
+* **Shape** — the current dimensions.
+* **Size** — the total number of elements.
+
+See also [Buffer queue](buffer-queue.html) for FIFO-style accumulation.

--- a/docs/reference-manual/processes/library/texture-to-buffer.md
+++ b/docs/reference-manual/processes/library/texture-to-buffer.md
@@ -1,0 +1,27 @@
+---
+layout: default
+
+title: Texture to buffer
+description: "Read back a GPU texture into a buffer"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/texture-to-buffer.html
+---
+# Texture to buffer
+
+<!-- TODO screenshot: ![Texture to buffer]({{ site.img }}/reference/processes/texture-to-buffer.png "Texture to buffer") -->
+
+Copies the contents of a GPU texture into a GPU buffer, so that pixel data produced on the
+graphics side can be consumed by processes that work on raw buffers. It is the inverse of
+[Array to texture](array-to-texture.html).
+
+## Texture
+
+The input texture to read.
+
+## Output
+
+A **GPU buffer** holding the texture's data, connectable to buffer-consuming processes
+(e.g. [Buffers to geometry](buffers-to-geometry.html)).

--- a/docs/reference-manual/processes/library/xwax-dvs.md
+++ b/docs/reference-manual/processes/library/xwax-dvs.md
@@ -1,0 +1,52 @@
+---
+layout: default
+
+title: XWax DVS
+description: "Decode digital vinyl system (DVS) timecode from turntables"
+
+parent: Processes
+grand_parent: Reference
+
+permalink: /processes/xwax-dvs.html
+---
+# XWax DVS
+
+<!-- TODO screenshot: ![XWax DVS]({{ site.img }}/reference/processes/xwax-dvs.png "XWax DVS") -->
+
+Decodes [Digital Vinyl System (DVS)](https://en.wikipedia.org/wiki/Vinyl_emulation)
+timecode from a turntable or CDJ feeding control-tone audio, using the
+[xwax](https://xwax.org/) decoder. This turns a real turntable into a controller: the
+decoded position and speed can scrub and pitch any time-based process in score.
+
+## Audio input
+
+A stereo audio bus carrying the timecode control tone from the deck.
+
+## Vinyl type
+
+The control-vinyl format to decode: **Serato**, **Traktor**, **MixVibes** or **Pioneer**.
+
+## Speed
+
+Nominal turntable speed: **33** or **45** RPM.
+
+## Pitch filter
+
+Smoothing applied to the recovered pitch, trading responsiveness for stability.
+
+## Lead-in time / Tempo
+
+Lead-in handling and reference tempo for the decoded transport.
+
+## Output format
+
+How the decoded position is presented on the **Timecode** output.
+
+## Outputs
+
+* **Timecode** — decoded position.
+* **Raw timecode** — undecoded raw value.
+* **Speed / Pitch** — playback speed and pitch deviation.
+* **Tempo** — derived tempo.
+* **Quality** — decode confidence, 0 to 1.
+* **Valid** — whether a usable signal is present.


### PR DESCRIPTION
- 6dfdcff — 18 process pages + automation.md filled + Counter section
- d1a5cf8 — 44 shader/JS preset pages
- 255cd68 — 3 nav index pages + nav_exclude

These doc pages are ready; note in the PR that the shader/JS pages become F1-reachable only after the §6 code (libisf DOCUMENTATION + JS @documentation parse) + user-library keys land.